### PR TITLE
Register Circuits by Key Globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ require "resilient/circuit_breaker"
 # CircuitBreaker.new as for keeps a registry of circuits by key to prevent
 # creating multiple instances of the same circuit breaker for a key; not using
 # `for` means you would have multiple instances of the circuit breaker and thus
-# separate state and metrics
+# separate state and metrics; you can read more in examples/for_vs_new.rb
 circuit_breaker = Resilient::CircuitBreaker.for(key: Resilient::Key.new("example"))
 if circuit_breaker.allow_request?
   begin

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or install it yourself as:
 require "resilient/circuit_breaker"
 
 # default properties for circuit
-circuit_breaker = Resilient::CircuitBreaker.new(key: Resilient::Key.new("example"))
+circuit_breaker = Resilient::CircuitBreaker.for(key: Resilient::Key.new("example"))
 if circuit_breaker.allow_request?
   begin
     # do something expensive
@@ -51,7 +51,7 @@ properties = Resilient::CircuitBreaker::Properties.new({
   # do not open circuit until at least 5 requests have happened
   request_volume_threshold: 5,
 })
-circuit_breaker = Resilient::CircuitBreaker.new(properties: properties, key: Resilient::Key.new("example"))
+circuit_breaker = Resilient::CircuitBreaker.for(properties: properties, key: Resilient::Key.new("example"))
 # etc etc etc
 ```
 
@@ -59,7 +59,7 @@ force the circuit to be always open:
 
 ```ruby
 properties = Resilient::CircuitBreaker::Properties.new(force_open: true)
-circuit_breaker = Resilient::CircuitBreaker.new(properties: properties, key: Resilient::Key.new("example"))
+circuit_breaker = Resilient::CircuitBreaker.for(properties: properties, key: Resilient::Key.new("example"))
 # etc etc etc
 ```
 
@@ -67,7 +67,7 @@ force the circuit to be always closed (great way to test in production with no i
 
 ```ruby
 properties = Resilient::CircuitBreaker::Properties.new(force_closed: true)
-circuit_breaker = Resilient::CircuitBreaker.new(properties: properties, key: Resilient::Key.new("example"))
+circuit_breaker = Resilient::CircuitBreaker.for(properties: properties, key: Resilient::Key.new("example"))
 # etc etc etc
 ```
 
@@ -78,7 +78,7 @@ metrics = Resilient::CircuitBreaker::Metrics.new({
   window_size_in_seconds: 10,
   bucket_size_in_seconds: 1,
 })
-circuit_breaker = Resilient::CircuitBreaker.new(metrics: metrics, key: Resilient::Key.new("example"))
+circuit_breaker = Resilient::CircuitBreaker.for(metrics: metrics, key: Resilient::Key.new("example"))
 # etc etc etc
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ Or install it yourself as:
 ```ruby
 require "resilient/circuit_breaker"
 
-# default properties for circuit, CircuitBreaker.for is used instead of
+# default properties for circuit, CircuitBreaker.get_instance is used instead of
 # CircuitBreaker.new as for keeps a registry of circuits by key to prevent
 # creating multiple instances of the same circuit breaker for a key; not using
 # `for` means you would have multiple instances of the circuit breaker and thus
 # separate state and metrics; you can read more in examples/for_vs_new.rb
-circuit_breaker = Resilient::CircuitBreaker.for(key: Resilient::Key.new("example"))
+circuit_breaker = Resilient::CircuitBreaker.get_instance(key: Resilient::Key.new("example"))
 if circuit_breaker.allow_request?
   begin
     # do something expensive
@@ -55,7 +55,7 @@ properties = Resilient::CircuitBreaker::Properties.new({
   # do not open circuit until at least 5 requests have happened
   request_volume_threshold: 5,
 })
-circuit_breaker = Resilient::CircuitBreaker.for(properties: properties, key: Resilient::Key.new("example"))
+circuit_breaker = Resilient::CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("example"))
 # etc etc etc
 ```
 
@@ -63,7 +63,7 @@ force the circuit to be always open:
 
 ```ruby
 properties = Resilient::CircuitBreaker::Properties.new(force_open: true)
-circuit_breaker = Resilient::CircuitBreaker.for(properties: properties, key: Resilient::Key.new("example"))
+circuit_breaker = Resilient::CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("example"))
 # etc etc etc
 ```
 
@@ -71,7 +71,7 @@ force the circuit to be always closed (great way to test in production with no i
 
 ```ruby
 properties = Resilient::CircuitBreaker::Properties.new(force_closed: true)
-circuit_breaker = Resilient::CircuitBreaker.for(properties: properties, key: Resilient::Key.new("example"))
+circuit_breaker = Resilient::CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("example"))
 # etc etc etc
 ```
 
@@ -82,7 +82,7 @@ metrics = Resilient::CircuitBreaker::Metrics.new({
   window_size_in_seconds: 10,
   bucket_size_in_seconds: 1,
 })
-circuit_breaker = Resilient::CircuitBreaker.for(metrics: metrics, key: Resilient::Key.new("example"))
+circuit_breaker = Resilient::CircuitBreaker.get_instance(metrics: metrics, key: Resilient::Key.new("example"))
 # etc etc etc
 ```
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ circuit_breaker = Resilient::CircuitBreaker.for(metrics: metrics, key: Resilient
 # etc etc etc
 ```
 
+## Tests
+
+To ensure that you have a clean circuit for each test case, be sure to run the following in the setup for your tests either before every test case or at a minimum each test case that uses circuit breakers.
+
+```ruby
+Resilient::CircuitBreaker.reset
+```
+
+This resets the global registry of circuits by key which effectively resets all state and metrics for the circuits.
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ Or install it yourself as:
 ```ruby
 require "resilient/circuit_breaker"
 
-# default properties for circuit
+# default properties for circuit, CircuitBreaker.for is used instead of
+# CircuitBreaker.new as for keeps a registry of circuits by key to prevent
+# creating multiple instances of the same circuit breaker for a key; not using
+# `for` means you would have multiple instances of the circuit breaker and thus
+# separate state and metrics
 circuit_breaker = Resilient::CircuitBreaker.for(key: Resilient::Key.new("example"))
 if circuit_breaker.allow_request?
   begin

--- a/README.md
+++ b/README.md
@@ -88,13 +88,11 @@ circuit_breaker = Resilient::CircuitBreaker.for(metrics: metrics, key: Resilient
 
 ## Tests
 
-To ensure that you have a clean circuit for each test case, be sure to run the following in the setup for your tests either before every test case or at a minimum each test case that uses circuit breakers.
+To ensure that you have a clean circuit for each test case, be sure to run the following in the setup for your tests (which resets each registered circuit breaker) either before every test case or at a minimum each test case that uses circuit breakers.
 
 ```ruby
 Resilient::CircuitBreaker.reset
 ```
-
-This resets the global registry of circuits by key which effectively resets all state and metrics for the circuits.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ Or install it yourself as:
 ```ruby
 require "resilient/circuit_breaker"
 
-# default properties for circuit, CircuitBreaker.get_instance is used instead of
+# default properties for circuit, CircuitBreaker.get is used instead of
 # CircuitBreaker.new as for keeps a registry of circuits by key to prevent
 # creating multiple instances of the same circuit breaker for a key; not using
 # `for` means you would have multiple instances of the circuit breaker and thus
 # separate state and metrics; you can read more in examples/for_vs_new.rb
-circuit_breaker = Resilient::CircuitBreaker.get_instance(key: Resilient::Key.new("example"))
+circuit_breaker = Resilient::CircuitBreaker.get(key: Resilient::Key.new("example"))
 if circuit_breaker.allow_request?
   begin
     # do something expensive
@@ -55,7 +55,7 @@ properties = Resilient::CircuitBreaker::Properties.new({
   # do not open circuit until at least 5 requests have happened
   request_volume_threshold: 5,
 })
-circuit_breaker = Resilient::CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("example"))
+circuit_breaker = Resilient::CircuitBreaker.get(properties: properties, key: Resilient::Key.new("example"))
 # etc etc etc
 ```
 
@@ -63,7 +63,7 @@ force the circuit to be always open:
 
 ```ruby
 properties = Resilient::CircuitBreaker::Properties.new(force_open: true)
-circuit_breaker = Resilient::CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("example"))
+circuit_breaker = Resilient::CircuitBreaker.get(properties: properties, key: Resilient::Key.new("example"))
 # etc etc etc
 ```
 
@@ -71,7 +71,7 @@ force the circuit to be always closed (great way to test in production with no i
 
 ```ruby
 properties = Resilient::CircuitBreaker::Properties.new(force_closed: true)
-circuit_breaker = Resilient::CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("example"))
+circuit_breaker = Resilient::CircuitBreaker.get(properties: properties, key: Resilient::Key.new("example"))
 # etc etc etc
 ```
 
@@ -82,7 +82,7 @@ metrics = Resilient::CircuitBreaker::Metrics.new({
   window_size_in_seconds: 10,
   bucket_size_in_seconds: 1,
 })
-circuit_breaker = Resilient::CircuitBreaker.get_instance(metrics: metrics, key: Resilient::Key.new("example"))
+circuit_breaker = Resilient::CircuitBreaker.get(metrics: metrics, key: Resilient::Key.new("example"))
 # etc etc etc
 ```
 

--- a/examples/basic.rb
+++ b/examples/basic.rb
@@ -13,7 +13,7 @@ properties = Resilient::CircuitBreaker::Properties.new({
   request_volume_threshold: 10,
   error_threshold_percentage: 25,
 })
-circuit_breaker = Resilient::CircuitBreaker.for(key: Resilient::Key.new("example"), properties: properties)
+circuit_breaker = Resilient::CircuitBreaker.get_instance(key: Resilient::Key.new("example"), properties: properties)
 
 # success
 if circuit_breaker.allow_request?

--- a/examples/basic.rb
+++ b/examples/basic.rb
@@ -13,7 +13,7 @@ properties = Resilient::CircuitBreaker::Properties.new({
   request_volume_threshold: 10,
   error_threshold_percentage: 25,
 })
-circuit_breaker = Resilient::CircuitBreaker.get_instance(key: Resilient::Key.new("example"), properties: properties)
+circuit_breaker = Resilient::CircuitBreaker.get(key: Resilient::Key.new("example"), properties: properties)
 
 # success
 if circuit_breaker.allow_request?

--- a/examples/basic.rb
+++ b/examples/basic.rb
@@ -13,7 +13,7 @@ properties = Resilient::CircuitBreaker::Properties.new({
   request_volume_threshold: 10,
   error_threshold_percentage: 25,
 })
-circuit_breaker = Resilient::CircuitBreaker.new(key: Resilient::Key.new("example"), properties: properties)
+circuit_breaker = Resilient::CircuitBreaker.for(key: Resilient::Key.new("example"), properties: properties)
 
 # success
 if circuit_breaker.allow_request?

--- a/examples/for_vs_new.rb
+++ b/examples/for_vs_new.rb
@@ -1,0 +1,37 @@
+# setting up load path
+require "pathname"
+root_path = Pathname(__FILE__).dirname.join("..").expand_path
+lib_path  = root_path.join("lib")
+$:.unshift(lib_path)
+
+# requiring stuff for this example
+require "pp"
+require "resilient/circuit_breaker"
+
+key = Resilient::Key.new("example")
+instance = Resilient::CircuitBreaker.for(key: key)
+instance_using_for = Resilient::CircuitBreaker.for(key: key)
+instance_using_new = Resilient::CircuitBreaker.new(key: key)
+
+puts "instance equals instance_using_for: #{instance.equal?(instance_using_for)}"
+puts "instance equals instance_using_new: #{instance.equal?(instance_using_new)}"
+
+instance.properties.request_volume_threshold.times do
+  instance.failure
+end
+
+puts "instance allow_request?: #{instance.allow_request?}"
+puts "instance_using_for allow_request?: #{instance_using_for.allow_request?}"
+
+# this instance allows the request because it isn't sharing internal state and
+# metrics due to being a new allocated instance; the for instance does not
+# suffer this because it looks up instances in a registry rather than always
+# generating a new instance even if you use the exact same key as it bypasses
+# the registry
+puts "instance_using_new allow_request?: #{instance_using_new.allow_request?}"
+
+# instance equals instance_using_for: true
+# instance equals instance_using_new: false
+# instance allow_request?: false
+# instance_using_for allow_request?: false
+# instance_using_new allow_request?: true

--- a/examples/for_vs_new.rb
+++ b/examples/for_vs_new.rb
@@ -13,8 +13,8 @@ require "pp"
 require "resilient/circuit_breaker"
 
 key = Resilient::Key.new("example")
-instance = Resilient::CircuitBreaker.get_instance(key: key)
-instance_using_for = Resilient::CircuitBreaker.get_instance(key: key)
+instance = Resilient::CircuitBreaker.get(key: key)
+instance_using_for = Resilient::CircuitBreaker.get(key: key)
 instance_using_new = Resilient::CircuitBreaker.new(key: key)
 
 puts "instance equals instance_using_for: #{instance.equal?(instance_using_for)}"

--- a/examples/for_vs_new.rb
+++ b/examples/for_vs_new.rb
@@ -4,6 +4,10 @@ root_path = Pathname(__FILE__).dirname.join("..").expand_path
 lib_path  = root_path.join("lib")
 $:.unshift(lib_path)
 
+# by default new is private so people don't use it, this makes it possible to
+# use it as resilient checks for this env var prior to privatizing new
+ENV["RESILIENT_PUBLICIZE_NEW"] = "1"
+
 # requiring stuff for this example
 require "pp"
 require "resilient/circuit_breaker"

--- a/examples/for_vs_new.rb
+++ b/examples/for_vs_new.rb
@@ -13,8 +13,8 @@ require "pp"
 require "resilient/circuit_breaker"
 
 key = Resilient::Key.new("example")
-instance = Resilient::CircuitBreaker.for(key: key)
-instance_using_for = Resilient::CircuitBreaker.for(key: key)
+instance = Resilient::CircuitBreaker.get_instance(key: key)
+instance_using_for = Resilient::CircuitBreaker.get_instance(key: key)
 instance_using_new = Resilient::CircuitBreaker.new(key: key)
 
 puts "instance equals instance_using_for: #{instance.equal?(instance_using_for)}"

--- a/examples/get_vs_new.rb
+++ b/examples/get_vs_new.rb
@@ -14,10 +14,10 @@ require "resilient/circuit_breaker"
 
 key = Resilient::Key.new("example")
 instance = Resilient::CircuitBreaker.get(key: key)
-instance_using_for = Resilient::CircuitBreaker.get(key: key)
+instance_using_get = Resilient::CircuitBreaker.get(key: key)
 instance_using_new = Resilient::CircuitBreaker.new(key: key)
 
-puts "instance equals instance_using_for: #{instance.equal?(instance_using_for)}"
+puts "instance equals instance_using_get: #{instance.equal?(instance_using_get)}"
 puts "instance equals instance_using_new: #{instance.equal?(instance_using_new)}"
 
 instance.properties.request_volume_threshold.times do
@@ -25,7 +25,7 @@ instance.properties.request_volume_threshold.times do
 end
 
 puts "instance allow_request?: #{instance.allow_request?}"
-puts "instance_using_for allow_request?: #{instance_using_for.allow_request?}"
+puts "instance_using_get allow_request?: #{instance_using_get.allow_request?}"
 
 # this instance allows the request because it isn't sharing internal state and
 # metrics due to being a new allocated instance; the for instance does not
@@ -34,8 +34,8 @@ puts "instance_using_for allow_request?: #{instance_using_for.allow_request?}"
 # the registry
 puts "instance_using_new allow_request?: #{instance_using_new.allow_request?}"
 
-# instance equals instance_using_for: true
+# instance equals instance_using_get: true
 # instance equals instance_using_new: false
 # instance allow_request?: false
-# instance_using_for allow_request?: false
+# instance_using_get allow_request?: false
 # instance_using_new allow_request?: true

--- a/examples/long_running.rb
+++ b/examples/long_running.rb
@@ -15,7 +15,7 @@ properties = Resilient::CircuitBreaker::Properties.new({
   window_size_in_seconds: 60,
   bucket_size_in_seconds: 1,
 })
-circuit_breaker = Resilient::CircuitBreaker.new(key: Resilient::Key.new("example"), properties: properties)
+circuit_breaker = Resilient::CircuitBreaker.for(key: Resilient::Key.new("example"), properties: properties)
 
 iterations = 0
 loop do

--- a/examples/long_running.rb
+++ b/examples/long_running.rb
@@ -15,7 +15,7 @@ properties = Resilient::CircuitBreaker::Properties.new({
   window_size_in_seconds: 60,
   bucket_size_in_seconds: 1,
 })
-circuit_breaker = Resilient::CircuitBreaker.for(key: Resilient::Key.new("example"), properties: properties)
+circuit_breaker = Resilient::CircuitBreaker.get_instance(key: Resilient::Key.new("example"), properties: properties)
 
 iterations = 0
 loop do

--- a/examples/long_running.rb
+++ b/examples/long_running.rb
@@ -15,7 +15,7 @@ properties = Resilient::CircuitBreaker::Properties.new({
   window_size_in_seconds: 60,
   bucket_size_in_seconds: 1,
 })
-circuit_breaker = Resilient::CircuitBreaker.get_instance(key: Resilient::Key.new("example"), properties: properties)
+circuit_breaker = Resilient::CircuitBreaker.get(key: Resilient::Key.new("example"), properties: properties)
 
 iterations = 0
 loop do

--- a/lib/resilient/circuit_breaker.rb
+++ b/lib/resilient/circuit_breaker.rb
@@ -6,7 +6,8 @@ require "resilient/circuit_breaker/registry"
 module Resilient
   class CircuitBreaker
     # Public: Resets all registered circuit breakers (and thus their state/metrics).
-    # Useful for ensuring a clean environment between tests.
+    # Useful for ensuring a clean environment between tests. If you are using a
+    # registry other than the default, you will need to handle resets on your own.
     def self.reset
       Registry.default.reset
     end
@@ -16,7 +17,7 @@ module Resilient
     # registered. If key does exist, it returns registered instance instead of
     # allocating a new instance in order to ensure that state/metrics are the
     # same per key.
-    def self.get_instance(key: nil, open: false, properties: nil, metrics: nil, registry: nil)
+    def self.get(key: nil, open: false, properties: nil, metrics: nil, registry: nil)
       (registry || Registry.default).fetch(key) {
         new(key: key, open: open, properties: properties, metrics: metrics)
       }

--- a/lib/resilient/circuit_breaker.rb
+++ b/lib/resilient/circuit_breaker.rb
@@ -22,9 +22,9 @@ module Resilient
     # key. If key does not exist, it is registered. If key does exist, it
     # returns registered instance instead of allocating a new instance in order
     # to ensure that state/metrics are the same per key.
-    def self.new(key: nil, open: false, properties: nil, metrics: nil)
+    def self.for(key: nil, open: false, properties: nil, metrics: nil)
       registry.fetch(key) {
-        super(key: key, open: open, properties: properties, metrics: metrics)
+        new(key: key, open: open, properties: properties, metrics: metrics)
       }
     end
 

--- a/lib/resilient/circuit_breaker.rb
+++ b/lib/resilient/circuit_breaker.rb
@@ -16,7 +16,7 @@ module Resilient
     # registered. If key does exist, it returns registered instance instead of
     # allocating a new instance in order to ensure that state/metrics are the
     # same per key.
-    def self.for(key: nil, open: false, properties: nil, metrics: nil, registry: nil)
+    def self.get_instance(key: nil, open: false, properties: nil, metrics: nil, registry: nil)
       (registry || Registry.default).fetch(key) {
         new(key: key, open: open, properties: properties, metrics: metrics)
       }

--- a/lib/resilient/circuit_breaker.rb
+++ b/lib/resilient/circuit_breaker.rb
@@ -5,25 +5,19 @@ require "resilient/circuit_breaker/registry"
 
 module Resilient
   class CircuitBreaker
-    # Public: Resets all registered circuit breakers (and thus there state/metrics).
+    # Public: Resets all registered circuit breakers (and thus their state/metrics).
     # Useful for ensuring a clean environment between tests.
     def self.reset
-      registry.reset
+      Registry.default.reset
     end
 
-    # Private: Registry that stores instances of circuit breakers to ensure that
-    # attempts to create new instances with the same key retain existing state/metrics.
-    def self.registry
-      @registry ||= Registry.new
-    end
-    class << self; private :registry; end
-
-    # Public: Overriden method to return instance of circuit breaker based on
-    # key. If key does not exist, it is registered. If key does exist, it
-    # returns registered instance instead of allocating a new instance in order
-    # to ensure that state/metrics are the same per key.
-    def self.for(key: nil, open: false, properties: nil, metrics: nil)
-      registry.fetch(key) {
+    # Public: Returns an instance of circuit breaker based on key and registry.
+    # Default registry is used if none is provided. If key does not exist, it is
+    # registered. If key does exist, it returns registered instance instead of
+    # allocating a new instance in order to ensure that state/metrics are the
+    # same per key.
+    def self.for(key: nil, open: false, properties: nil, metrics: nil, registry: nil)
+      (registry || Registry.default).fetch(key) {
         new(key: key, open: open, properties: properties, metrics: metrics)
       }
     end

--- a/lib/resilient/circuit_breaker.rb
+++ b/lib/resilient/circuit_breaker.rb
@@ -22,6 +22,12 @@ module Resilient
       }
     end
 
+    unless ENV.key?("RESILIENT_PUBLICIZE_NEW")
+      class << self
+        private :new
+      end
+    end
+
     attr_reader :key
     attr_reader :open
     attr_reader :opened_or_last_checked_at_epoch

--- a/lib/resilient/circuit_breaker/registry.rb
+++ b/lib/resilient/circuit_breaker/registry.rb
@@ -38,7 +38,7 @@ module Resilient
       # breakers, which should only really be used for cleaning up in
       # test environment.
       def reset
-        @source.clear
+        @source.each_value(&:reset)
         nil
       end
     end

--- a/lib/resilient/circuit_breaker/registry.rb
+++ b/lib/resilient/circuit_breaker/registry.rb
@@ -5,8 +5,8 @@ module Resilient
         @source = source || {}
       end
 
-      # Internal: To be used by CircuitBreaker to either get an instance for a key
-      # or set a new instance for a key.
+      # Internal: To be used by CircuitBreaker to either get an instance for a
+      # key or set a new instance for a key.
       #
       # Raises KeyError if key not found and no block provided.
       def fetch(key, &block)

--- a/lib/resilient/circuit_breaker/registry.rb
+++ b/lib/resilient/circuit_breaker/registry.rb
@@ -1,0 +1,33 @@
+module Resilient
+  class CircuitBreaker
+    class Registry
+      def initialize(source = nil)
+        @source = source || {}
+      end
+
+      # Internal: To be used by CircuitBreaker to either get an instance for a key
+      # or set a new instance for a key.
+      #
+      # Raises KeyError if key not found and no block provided.
+      def fetch(key, &block)
+        if value = @source[key]
+          value
+        else
+          if block_given?
+            @source[key] = yield
+          else
+            @source.fetch(key)
+          end
+        end
+      end
+
+      # Internal: To be used by CircuitBreaker to reset the stored circuit
+      # breakers, which should only really be used for cleaning up in
+      # test environment.
+      def reset
+        @source.clear
+        nil
+      end
+    end
+  end
+end

--- a/lib/resilient/circuit_breaker/registry.rb
+++ b/lib/resilient/circuit_breaker/registry.rb
@@ -1,9 +1,22 @@
 module Resilient
   class CircuitBreaker
     class Registry
+      # Internal: Default registry to use for circuit breakers.
+      def self.default
+        @default
+      end
+
+      # Internal: Allows overriding default registry for circuit breakers.
+      def self.default=(value)
+        @default = value
+      end
+
       def initialize(source = nil)
         @source = source || {}
       end
+
+      # Setup default to new instance.
+      @default = new
 
       # Internal: To be used by CircuitBreaker to either get an instance for a
       # key or set a new instance for a key.

--- a/lib/resilient/instrumenters/memory.rb
+++ b/lib/resilient/instrumenters/memory.rb
@@ -8,7 +8,7 @@ module Resilient
       attr_reader :events
 
       def initialize
-        @events = []
+        reset
       end
 
       def instrument(name, payload = {})
@@ -24,6 +24,10 @@ module Resilient
         end
         @events << Event.new(name, payload, result)
         result
+      end
+
+      def reset
+        @events = []
       end
     end
   end

--- a/lib/resilient/key.rb
+++ b/lib/resilient/key.rb
@@ -3,7 +3,16 @@ module Resilient
     attr_reader :name
 
     def initialize(name)
-      @name = name
+      @name = name.to_s
+    end
+
+    def ==(other)
+      self.class == other.class && name == other.name
+    end
+    alias_method :eql?, :==
+
+    def hash
+      @name.hash
     end
   end
 end

--- a/lib/resilient/test/circuit_breaker_registry_interface.rb
+++ b/lib/resilient/test/circuit_breaker_registry_interface.rb
@@ -1,0 +1,34 @@
+module Resilient
+  class Test
+    module CircuitBreakerRegistryInterface
+      def test_responds_to_fetch
+        assert_respond_to @object, :fetch
+      end
+
+      def test_responds_to_reset
+        assert_respond_to @object, :reset
+      end
+
+      def test_fetch
+        key = "foo"
+        value = "bar".freeze
+
+        assert_raises(KeyError) { @object.fetch(key) }
+        assert_equal value, @object.fetch(key) { value }
+        assert_equal value, @object.fetch(key)
+        assert @object.fetch(key).equal?(value)
+      end
+
+      def test_reset
+        assert_nil @object.reset
+
+        @object.fetch("foo") { "bar" }
+        @object.fetch("baz") { "wick" }
+
+        assert_nil @object.reset
+        assert_raises(KeyError) { @object.fetch("foo") }
+        assert_raises(KeyError) { @object.fetch("baz") }
+      end
+    end
+  end
+end

--- a/lib/resilient/test/circuit_breaker_registry_interface.rb
+++ b/lib/resilient/test/circuit_breaker_registry_interface.rb
@@ -20,14 +20,22 @@ module Resilient
       end
 
       def test_reset
+        bar_value = Minitest::Mock.new
+        wick_value = Minitest::Mock.new
+        bar_value.expect :reset, nil, []
+        wick_value.expect :reset, nil, []
+
+        @object.fetch("foo") { bar_value }
+        @object.fetch("baz") { wick_value }
+
         assert_nil @object.reset
 
-        @object.fetch("foo") { "bar" }
-        @object.fetch("baz") { "wick" }
+        bar_value.verify
+        wick_value.verify
+      end
 
+      def test_reset_empty_registry
         assert_nil @object.reset
-        assert_raises(KeyError) { @object.fetch("foo") }
-        assert_raises(KeyError) { @object.fetch("baz") }
       end
     end
   end

--- a/test/resilient/circuit_breaker/metrics/storage/memory_test.rb
+++ b/test/resilient/circuit_breaker/metrics/storage/memory_test.rb
@@ -6,7 +6,7 @@ module Resilient
   class CircuitBreaker
     class Metrics
       module Storage
-        class MemoryTest < Resilient::Test
+        class MemoryTest < Test
           def setup
             super
             @object = Memory.new

--- a/test/resilient/circuit_breaker/metrics/storage/memory_test.rb
+++ b/test/resilient/circuit_breaker/metrics/storage/memory_test.rb
@@ -8,6 +8,7 @@ module Resilient
       module Storage
         class MemoryTest < Resilient::Test
           def setup
+            super
             @object = Memory.new
           end
 

--- a/test/resilient/circuit_breaker/metrics_test.rb
+++ b/test/resilient/circuit_breaker/metrics_test.rb
@@ -4,7 +4,7 @@ require "resilient/test/metrics_interface"
 
 module Resilient
   class CircuitBreaker
-    class MetricsTest < Resilient::Test
+    class MetricsTest < Test
       def setup
         super
         @object = Metrics.new(window_size_in_seconds: 5, bucket_size_in_seconds: 1)

--- a/test/resilient/circuit_breaker/metrics_test.rb
+++ b/test/resilient/circuit_breaker/metrics_test.rb
@@ -6,6 +6,7 @@ module Resilient
   class CircuitBreaker
     class MetricsTest < Resilient::Test
       def setup
+        super
         @object = Metrics.new(window_size_in_seconds: 5, bucket_size_in_seconds: 1)
       end
 

--- a/test/resilient/circuit_breaker/properties_test.rb
+++ b/test/resilient/circuit_breaker/properties_test.rb
@@ -8,6 +8,7 @@ module Resilient
   class CircuitBreaker
     class PropertiesTest < Resilient::Test
       def setup
+        super
         @object = Properties.new
       end
 

--- a/test/resilient/circuit_breaker/properties_test.rb
+++ b/test/resilient/circuit_breaker/properties_test.rb
@@ -6,7 +6,7 @@ require "resilient/test/properties_interface"
 
 module Resilient
   class CircuitBreaker
-    class PropertiesTest < Resilient::Test
+    class PropertiesTest < Test
       def setup
         super
         @object = Properties.new

--- a/test/resilient/circuit_breaker/registry_test.rb
+++ b/test/resilient/circuit_breaker/registry_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+require "resilient/circuit_breaker/registry"
+require "resilient/test/circuit_breaker_registry_interface"
+
+module Resilient
+  class CircuitBreaker
+    class RegistryTest < Resilient::Test
+      def setup
+        @object = Registry.new
+      end
+
+      include Test::CircuitBreakerRegistryInterface
+    end
+  end
+end

--- a/test/resilient/circuit_breaker/registry_test.rb
+++ b/test/resilient/circuit_breaker/registry_test.rb
@@ -6,6 +6,7 @@ module Resilient
   class CircuitBreaker
     class RegistryTest < Resilient::Test
       def setup
+        super
         @object = Registry.new
       end
 

--- a/test/resilient/circuit_breaker/registry_test.rb
+++ b/test/resilient/circuit_breaker/registry_test.rb
@@ -11,6 +11,15 @@ module Resilient
       end
 
       include Test::CircuitBreakerRegistryInterface
+
+      def test_default_class_accessors
+        original_default = Registry.default
+        assert_instance_of Registry, Registry.default
+        Registry.default = @object
+        assert_equal @object, Registry.default
+      ensure
+        Registry.default = original_default
+      end
     end
   end
 end

--- a/test/resilient/circuit_breaker/registry_test.rb
+++ b/test/resilient/circuit_breaker/registry_test.rb
@@ -4,7 +4,7 @@ require "resilient/test/circuit_breaker_registry_interface"
 
 module Resilient
   class CircuitBreaker
-    class RegistryTest < Resilient::Test
+    class RegistryTest < Test
       def setup
         super
         @object = Registry.new

--- a/test/resilient/circuit_breaker_instrumentation_test.rb
+++ b/test/resilient/circuit_breaker_instrumentation_test.rb
@@ -4,7 +4,7 @@ require "resilient/circuit_breaker/properties"
 require "resilient/circuit_breaker/metrics/storage/memory"
 
 module Resilient
-  class CircuitBreakerInstrumentationTest < Resilient::Test
+  class CircuitBreakerInstrumentationTest < Test
     def test_instruments_allow_request
       instrumenter = Instrumenters::Memory.new
       properties = CircuitBreaker::Properties.new({

--- a/test/resilient/circuit_breaker_instrumentation_test.rb
+++ b/test/resilient/circuit_breaker_instrumentation_test.rb
@@ -11,7 +11,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new({
         instrumenter: instrumenter,
       })
-      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
       assert circuit_breaker.allow_request?
       event = instrumenter.events.detect { |event| event.name =~ /allow_request/ }
       refute_nil event
@@ -35,7 +35,7 @@ module Resilient
         instrumenter: instrumenter,
         force_open: true,
       })
-      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
       refute circuit_breaker.allow_request?
       event = instrumenter.events.first
       refute_nil event
@@ -54,7 +54,7 @@ module Resilient
         instrumenter: instrumenter,
         force_closed: true,
       })
-      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
       assert circuit_breaker.allow_request?
       event = instrumenter.events.detect { |event| event.name =~ /allow_request/ }
       refute_nil event
@@ -79,7 +79,7 @@ module Resilient
         error_threshold_percentage: 50,
         request_volume_threshold: 0,
       })
-      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.failure
       assert circuit_breaker.allow_request?
       event = instrumenter.events.detect { |event|
@@ -112,7 +112,7 @@ module Resilient
         request_volume_threshold: 0,
         sleep_window_seconds: 1,
       })
-      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.failure
       assert circuit_breaker.allow_request?
 
@@ -149,7 +149,7 @@ module Resilient
         error_threshold_percentage: 50,
         request_volume_threshold: 0,
       })
-      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.properties.instrumenter.reset
       circuit_breaker.failure
       refute circuit_breaker.allow_request?
@@ -182,7 +182,7 @@ module Resilient
         request_volume_threshold: 0,
         sleep_window_seconds: 1,
       })
-      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.failure
       refute circuit_breaker.allow_request?
 
@@ -217,7 +217,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new({
         instrumenter: instrumenter,
       })
-      circuit_breaker = CircuitBreaker.for(open: false, properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(open: false, properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       event = instrumenter.events.first
       refute_nil event
@@ -231,7 +231,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new({
         instrumenter: instrumenter,
       })
-      circuit_breaker = CircuitBreaker.for(open: true, properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(open: true, properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       event = instrumenter.events.first
       refute_nil event
@@ -245,7 +245,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new({
         instrumenter: instrumenter,
       })
-      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.failure
       event = instrumenter.events.first
       refute_nil event
@@ -258,7 +258,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new({
         instrumenter: instrumenter,
       })
-      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.reset
       event = instrumenter.events.first
       refute_nil event

--- a/test/resilient/circuit_breaker_instrumentation_test.rb
+++ b/test/resilient/circuit_breaker_instrumentation_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "resilient/circuit_breaker"
+require "resilient/instrumenters/memory"
 require "resilient/circuit_breaker/properties"
 require "resilient/circuit_breaker/metrics/storage/memory"
 
@@ -10,7 +11,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new({
         instrumenter: instrumenter,
       })
-      circuit_breaker = CircuitBreaker.new(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
       assert circuit_breaker.allow_request?
       event = instrumenter.events.detect { |event| event.name =~ /allow_request/ }
       refute_nil event
@@ -34,7 +35,7 @@ module Resilient
         instrumenter: instrumenter,
         force_open: true,
       })
-      circuit_breaker = CircuitBreaker.new(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
       refute circuit_breaker.allow_request?
       event = instrumenter.events.first
       refute_nil event
@@ -53,7 +54,7 @@ module Resilient
         instrumenter: instrumenter,
         force_closed: true,
       })
-      circuit_breaker = CircuitBreaker.new(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
       assert circuit_breaker.allow_request?
       event = instrumenter.events.detect { |event| event.name =~ /allow_request/ }
       refute_nil event
@@ -78,7 +79,7 @@ module Resilient
         error_threshold_percentage: 50,
         request_volume_threshold: 0,
       })
-      circuit_breaker = CircuitBreaker.new(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.failure
       assert circuit_breaker.allow_request?
       event = instrumenter.events.detect { |event|
@@ -111,7 +112,7 @@ module Resilient
         request_volume_threshold: 0,
         sleep_window_seconds: 1,
       })
-      circuit_breaker = CircuitBreaker.new(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.failure
       assert circuit_breaker.allow_request?
 
@@ -148,7 +149,8 @@ module Resilient
         error_threshold_percentage: 50,
         request_volume_threshold: 0,
       })
-      circuit_breaker = CircuitBreaker.new(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker.properties.instrumenter.reset
       circuit_breaker.failure
       refute circuit_breaker.allow_request?
       event = instrumenter.events.detect { |event|
@@ -180,7 +182,7 @@ module Resilient
         request_volume_threshold: 0,
         sleep_window_seconds: 1,
       })
-      circuit_breaker = CircuitBreaker.new(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.failure
       refute circuit_breaker.allow_request?
 
@@ -215,7 +217,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new({
         instrumenter: instrumenter,
       })
-      circuit_breaker = CircuitBreaker.new(open: false, properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(open: false, properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       event = instrumenter.events.first
       refute_nil event
@@ -229,7 +231,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new({
         instrumenter: instrumenter,
       })
-      circuit_breaker = CircuitBreaker.new(open: true, properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(open: true, properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       event = instrumenter.events.first
       refute_nil event
@@ -243,7 +245,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new({
         instrumenter: instrumenter,
       })
-      circuit_breaker = CircuitBreaker.new(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.failure
       event = instrumenter.events.first
       refute_nil event
@@ -256,7 +258,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new({
         instrumenter: instrumenter,
       })
-      circuit_breaker = CircuitBreaker.new(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.reset
       event = instrumenter.events.first
       refute_nil event

--- a/test/resilient/circuit_breaker_instrumentation_test.rb
+++ b/test/resilient/circuit_breaker_instrumentation_test.rb
@@ -11,7 +11,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new({
         instrumenter: instrumenter,
       })
-      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       assert circuit_breaker.allow_request?
       event = instrumenter.events.detect { |event| event.name =~ /allow_request/ }
       refute_nil event
@@ -35,7 +35,7 @@ module Resilient
         instrumenter: instrumenter,
         force_open: true,
       })
-      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       refute circuit_breaker.allow_request?
       event = instrumenter.events.first
       refute_nil event
@@ -54,7 +54,7 @@ module Resilient
         instrumenter: instrumenter,
         force_closed: true,
       })
-      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       assert circuit_breaker.allow_request?
       event = instrumenter.events.detect { |event| event.name =~ /allow_request/ }
       refute_nil event
@@ -79,7 +79,7 @@ module Resilient
         error_threshold_percentage: 50,
         request_volume_threshold: 0,
       })
-      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.failure
       assert circuit_breaker.allow_request?
       event = instrumenter.events.detect { |event|
@@ -112,7 +112,7 @@ module Resilient
         request_volume_threshold: 0,
         sleep_window_seconds: 1,
       })
-      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.failure
       assert circuit_breaker.allow_request?
 
@@ -149,7 +149,7 @@ module Resilient
         error_threshold_percentage: 50,
         request_volume_threshold: 0,
       })
-      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.properties.instrumenter.reset
       circuit_breaker.failure
       refute circuit_breaker.allow_request?
@@ -182,7 +182,7 @@ module Resilient
         request_volume_threshold: 0,
         sleep_window_seconds: 1,
       })
-      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.failure
       refute circuit_breaker.allow_request?
 
@@ -217,7 +217,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new({
         instrumenter: instrumenter,
       })
-      circuit_breaker = CircuitBreaker.get_instance(open: false, properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(open: false, properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       event = instrumenter.events.first
       refute_nil event
@@ -231,7 +231,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new({
         instrumenter: instrumenter,
       })
-      circuit_breaker = CircuitBreaker.get_instance(open: true, properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(open: true, properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       event = instrumenter.events.first
       refute_nil event
@@ -245,7 +245,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new({
         instrumenter: instrumenter,
       })
-      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.failure
       event = instrumenter.events.first
       refute_nil event
@@ -258,7 +258,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new({
         instrumenter: instrumenter,
       })
-      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.reset
       event = instrumenter.events.first
       refute_nil event

--- a/test/resilient/circuit_breaker_integration_test.rb
+++ b/test/resilient/circuit_breaker_integration_test.rb
@@ -10,7 +10,7 @@ module Resilient
         window_size_in_seconds: 60,
         bucket_size_in_seconds: 10,
       })
-      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
       70.times { circuit_breaker.success }
       assert circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
@@ -35,7 +35,7 @@ module Resilient
         window_size_in_seconds: 60,
         bucket_size_in_seconds: 10,
       })
-      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
       18.times { circuit_breaker.failure }
       assert circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
@@ -51,7 +51,7 @@ module Resilient
         request_volume_threshold: 0,
         force_open: true,
       })
-      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
       refute circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
 
@@ -66,7 +66,7 @@ module Resilient
         request_volume_threshold: 0,
         force_closed: true,
       })
-      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
       assert circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
 
@@ -81,7 +81,7 @@ module Resilient
         force_closed: true,
         force_open: true,
       })
-      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
       refute circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
     end
@@ -93,7 +93,7 @@ module Resilient
         window_size_in_seconds: 60,
         bucket_size_in_seconds: 10,
       })
-      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
       now = Time.now
       bucket1 = now
       bucket2 = now + 10

--- a/test/resilient/circuit_breaker_integration_test.rb
+++ b/test/resilient/circuit_breaker_integration_test.rb
@@ -10,7 +10,7 @@ module Resilient
         window_size_in_seconds: 60,
         bucket_size_in_seconds: 10,
       })
-      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       70.times { circuit_breaker.success }
       assert circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
@@ -35,7 +35,7 @@ module Resilient
         window_size_in_seconds: 60,
         bucket_size_in_seconds: 10,
       })
-      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       18.times { circuit_breaker.failure }
       assert circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
@@ -51,7 +51,7 @@ module Resilient
         request_volume_threshold: 0,
         force_open: true,
       })
-      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       refute circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
 
@@ -66,7 +66,7 @@ module Resilient
         request_volume_threshold: 0,
         force_closed: true,
       })
-      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       assert circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
 
@@ -81,7 +81,7 @@ module Resilient
         force_closed: true,
         force_open: true,
       })
-      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       refute circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
     end
@@ -93,7 +93,7 @@ module Resilient
         window_size_in_seconds: 60,
         bucket_size_in_seconds: 10,
       })
-      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       now = Time.now
       bucket1 = now
       bucket2 = now + 10

--- a/test/resilient/circuit_breaker_integration_test.rb
+++ b/test/resilient/circuit_breaker_integration_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 require "resilient/circuit_breaker"
 
 module Resilient
-  class CircuitBreakerIntegrationTest < Resilient::Test
+  class CircuitBreakerIntegrationTest < Test
     def test_enough_failures_in_time_window_open_circuit
       properties = CircuitBreaker::Properties.new({
         error_threshold_percentage: 25,

--- a/test/resilient/circuit_breaker_integration_test.rb
+++ b/test/resilient/circuit_breaker_integration_test.rb
@@ -10,7 +10,7 @@ module Resilient
         window_size_in_seconds: 60,
         bucket_size_in_seconds: 10,
       })
-      circuit_breaker = CircuitBreaker.new(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
       70.times { circuit_breaker.success }
       assert circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
@@ -35,7 +35,7 @@ module Resilient
         window_size_in_seconds: 60,
         bucket_size_in_seconds: 10,
       })
-      circuit_breaker = CircuitBreaker.new(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
       18.times { circuit_breaker.failure }
       assert circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
@@ -51,7 +51,7 @@ module Resilient
         request_volume_threshold: 0,
         force_open: true,
       })
-      circuit_breaker = CircuitBreaker.new(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
       refute circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
 
@@ -66,7 +66,7 @@ module Resilient
         request_volume_threshold: 0,
         force_closed: true,
       })
-      circuit_breaker = CircuitBreaker.new(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
       assert circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
 
@@ -81,7 +81,7 @@ module Resilient
         force_closed: true,
         force_open: true,
       })
-      circuit_breaker = CircuitBreaker.new(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
       refute circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
     end
@@ -93,7 +93,7 @@ module Resilient
         window_size_in_seconds: 60,
         bucket_size_in_seconds: 10,
       })
-      circuit_breaker = CircuitBreaker.new(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
       now = Time.now
       bucket1 = now
       bucket2 = now + 10

--- a/test/resilient/circuit_breaker_test.rb
+++ b/test/resilient/circuit_breaker_test.rb
@@ -3,7 +3,7 @@ require "resilient/circuit_breaker"
 require "resilient/test/circuit_breaker_interface"
 
 module Resilient
-  class CircuitBreakerTest < Resilient::Test
+  class CircuitBreakerTest < Test
     def setup
       super
       @object = CircuitBreaker.new(key: Resilient::Key.new("object"))

--- a/test/resilient/circuit_breaker_test.rb
+++ b/test/resilient/circuit_breaker_test.rb
@@ -6,21 +6,21 @@ module Resilient
   class CircuitBreakerTest < Test
     def setup
       super
-      @object = CircuitBreaker.get_instance(key: Resilient::Key.new("object"))
+      @object = CircuitBreaker.get(key: Resilient::Key.new("object"))
     end
 
     include Test::CircuitBreakerInterface
 
     def test_for
-      first_initialization = CircuitBreaker.get_instance(key: Resilient::Key.new("longmire"))
+      first_initialization = CircuitBreaker.get(key: Resilient::Key.new("longmire"))
       assert_instance_of CircuitBreaker, first_initialization
 
-      second_initialization = CircuitBreaker.get_instance(key: Resilient::Key.new("longmire"))
+      second_initialization = CircuitBreaker.get(key: Resilient::Key.new("longmire"))
       assert_instance_of CircuitBreaker, second_initialization
       assert first_initialization.equal?(second_initialization),
         "#{first_initialization.inspect} is not the exact same object as #{second_initialization.inspect}"
 
-      symbol_initialization = CircuitBreaker.get_instance(key: Resilient::Key.new(:longmire))
+      symbol_initialization = CircuitBreaker.get(key: Resilient::Key.new(:longmire))
       assert_instance_of CircuitBreaker, symbol_initialization
       assert first_initialization.equal?(symbol_initialization),
         "#{first_initialization.inspect} is not the exact same object as #{symbol_initialization.inspect}"
@@ -28,17 +28,17 @@ module Resilient
 
     def test_for_with_nil_key
       assert_raises ArgumentError do
-        CircuitBreaker.get_instance(key: nil)
+        CircuitBreaker.get(key: nil)
       end
     end
 
     def test_for_with_different_properties_than_initially_provided
       key = Resilient::Key.new("longmire")
       original_properties = CircuitBreaker::Properties.new(error_threshold_percentage: 10)
-      circuit_breaker = CircuitBreaker.get_instance(key: key, properties: original_properties)
+      circuit_breaker = CircuitBreaker.get(key: key, properties: original_properties)
 
       different_properties = CircuitBreaker::Properties.new(error_threshold_percentage: 15)
-      different_properties_circuit_breaker = CircuitBreaker.get_instance(key: key, properties: different_properties)
+      different_properties_circuit_breaker = CircuitBreaker.get(key: key, properties: different_properties)
 
       assert_equal original_properties.error_threshold_percentage,
         different_properties_circuit_breaker.properties.error_threshold_percentage
@@ -58,7 +58,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new(default_test_properties_options({
         error_threshold_percentage: 51,
       }))
-      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -70,7 +70,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new(default_test_properties_options({
         error_threshold_percentage: 49,
       }))
-      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -82,7 +82,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new(default_test_properties_options({
         error_threshold_percentage: 50,
       }))
-      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -94,7 +94,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new(default_test_properties_options({
         request_volume_threshold: 5,
       }))
-      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       4.times { circuit_breaker.metrics.failure }
 
       assert circuit_breaker.allow_request?,
@@ -107,7 +107,7 @@ module Resilient
         error_threshold_percentage: 49,
         sleep_window_seconds: 5,
       }))
-      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -145,7 +145,7 @@ module Resilient
         error_threshold_percentage: 51,
         force_open: true,
       }))
-      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -159,7 +159,7 @@ module Resilient
         request_volume_threshold: 0,
         force_closed: true,
       }))
-      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -169,7 +169,7 @@ module Resilient
 
     def test_success_when_open_does_reset_metrics
       metrics = Minitest::Mock.new
-      circuit_breaker = CircuitBreaker.get_instance(open: true, metrics: metrics, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(open: true, metrics: metrics, key: Resilient::Key.new("test"))
 
       metrics.expect :reset, nil
       circuit_breaker.success
@@ -178,7 +178,7 @@ module Resilient
 
     def test_success_when_not_open_calls_success_on_metrics
       metrics = Minitest::Mock.new
-      circuit_breaker = CircuitBreaker.get_instance(open: false, metrics: metrics, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(open: false, metrics: metrics, key: Resilient::Key.new("test"))
 
       metrics.expect :success, nil
       circuit_breaker.success
@@ -187,7 +187,7 @@ module Resilient
 
     def test_failure_calls_failure_on_metrics
       metrics = Minitest::Mock.new
-      circuit_breaker = CircuitBreaker.get_instance(metrics: metrics, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(metrics: metrics, key: Resilient::Key.new("test"))
 
       metrics.expect :failure, nil
       circuit_breaker.failure
@@ -196,7 +196,7 @@ module Resilient
 
     def test_reset_calls_reset_on_metrics
       metrics = Minitest::Mock.new
-      circuit_breaker = CircuitBreaker.get_instance(metrics: metrics, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(metrics: metrics, key: Resilient::Key.new("test"))
 
       metrics.expect :reset, nil
       circuit_breaker.reset
@@ -204,14 +204,14 @@ module Resilient
     end
 
     def test_reset_sets_open_to_false
-      circuit_breaker = CircuitBreaker.get_instance(key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(key: Resilient::Key.new("test"))
       circuit_breaker.reset
 
       assert_equal false, circuit_breaker.open
     end
 
     def test_reset_sets_opened_or_last_checked_at_epoch_to_zero
-      circuit_breaker = CircuitBreaker.get_instance(key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(key: Resilient::Key.new("test"))
       circuit_breaker.reset
 
       assert_equal 0, circuit_breaker.opened_or_last_checked_at_epoch

--- a/test/resilient/circuit_breaker_test.rb
+++ b/test/resilient/circuit_breaker_test.rb
@@ -6,25 +6,28 @@ module Resilient
   class CircuitBreakerTest < Resilient::Test
     def setup
       super
-      @object = CircuitBreaker.new(key: Resilient::Key.new("test"))
+      @object = CircuitBreaker.new(key: Resilient::Key.new("object"))
     end
 
     include Test::CircuitBreakerInterface
 
     def test_new
-      key = Resilient::Key.new("longmire")
-      first_initialization = CircuitBreaker.new(key: key)
+      first_initialization = CircuitBreaker.new(key: Resilient::Key.new("longmire"))
       assert_instance_of CircuitBreaker, first_initialization
 
-      second_initialization = CircuitBreaker.new(key: key)
+      second_initialization = CircuitBreaker.new(key: Resilient::Key.new("longmire"))
       assert_instance_of CircuitBreaker, second_initialization
-
       assert first_initialization.equal?(second_initialization),
         "#{first_initialization.inspect} is not the exact same object as #{second_initialization.inspect}"
+
+      symbol_initialization = CircuitBreaker.new(key: Resilient::Key.new(:longmire))
+      assert_instance_of CircuitBreaker, symbol_initialization
+      assert first_initialization.equal?(symbol_initialization),
+        "#{first_initialization.inspect} is not the exact same object as #{symbol_initialization.inspect}"
     end
 
     def test_key
-      assert_equal "test", @object.key.name
+      assert_equal "object", @object.key.name
     end
 
     def test_allow_request_when_under_error_threshold_percentage

--- a/test/resilient/circuit_breaker_test.rb
+++ b/test/resilient/circuit_breaker_test.rb
@@ -6,7 +6,7 @@ module Resilient
   class CircuitBreakerTest < Test
     def setup
       super
-      @object = CircuitBreaker.new(key: Resilient::Key.new("object"))
+      @object = CircuitBreaker.for(key: Resilient::Key.new("object"))
     end
 
     include Test::CircuitBreakerInterface
@@ -26,6 +26,12 @@ module Resilient
         "#{first_initialization.inspect} is not the exact same object as #{symbol_initialization.inspect}"
     end
 
+    def test_new
+      assert_raises NoMethodError do
+        CircuitBreaker.new(key: Resilient::Key.new("test"))
+      end
+    end
+
     def test_key
       assert_equal "object", @object.key.name
     end
@@ -34,7 +40,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new(default_test_properties_options({
         error_threshold_percentage: 51,
       }))
-      circuit_breaker = CircuitBreaker.new(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -46,7 +52,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new(default_test_properties_options({
         error_threshold_percentage: 49,
       }))
-      circuit_breaker = CircuitBreaker.new(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -58,7 +64,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new(default_test_properties_options({
         error_threshold_percentage: 50,
       }))
-      circuit_breaker = CircuitBreaker.new(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -70,7 +76,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new(default_test_properties_options({
         request_volume_threshold: 5,
       }))
-      circuit_breaker = CircuitBreaker.new(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
       4.times { circuit_breaker.metrics.failure }
 
       assert circuit_breaker.allow_request?,
@@ -83,7 +89,7 @@ module Resilient
         error_threshold_percentage: 49,
         sleep_window_seconds: 5,
       }))
-      circuit_breaker = CircuitBreaker.new(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -121,7 +127,7 @@ module Resilient
         error_threshold_percentage: 51,
         force_open: true,
       }))
-      circuit_breaker = CircuitBreaker.new(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -135,7 +141,7 @@ module Resilient
         request_volume_threshold: 0,
         force_closed: true,
       }))
-      circuit_breaker = CircuitBreaker.new(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -145,7 +151,7 @@ module Resilient
 
     def test_success_when_open_does_reset_metrics
       metrics = Minitest::Mock.new
-      circuit_breaker = CircuitBreaker.new(open: true, metrics: metrics, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(open: true, metrics: metrics, key: Resilient::Key.new("test"))
 
       metrics.expect :reset, nil
       circuit_breaker.success
@@ -154,7 +160,7 @@ module Resilient
 
     def test_success_when_not_open_calls_success_on_metrics
       metrics = Minitest::Mock.new
-      circuit_breaker = CircuitBreaker.new(open: false, metrics: metrics, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(open: false, metrics: metrics, key: Resilient::Key.new("test"))
 
       metrics.expect :success, nil
       circuit_breaker.success
@@ -163,7 +169,7 @@ module Resilient
 
     def test_failure_calls_failure_on_metrics
       metrics = Minitest::Mock.new
-      circuit_breaker = CircuitBreaker.new(metrics: metrics, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(metrics: metrics, key: Resilient::Key.new("test"))
 
       metrics.expect :failure, nil
       circuit_breaker.failure
@@ -172,7 +178,7 @@ module Resilient
 
     def test_reset_calls_reset_on_metrics
       metrics = Minitest::Mock.new
-      circuit_breaker = CircuitBreaker.new(metrics: metrics, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(metrics: metrics, key: Resilient::Key.new("test"))
 
       metrics.expect :reset, nil
       circuit_breaker.reset
@@ -180,14 +186,14 @@ module Resilient
     end
 
     def test_reset_sets_open_to_false
-      circuit_breaker = CircuitBreaker.new(key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(key: Resilient::Key.new("test"))
       circuit_breaker.reset
 
       assert_equal false, circuit_breaker.open
     end
 
     def test_reset_sets_opened_or_last_checked_at_epoch_to_zero
-      circuit_breaker = CircuitBreaker.new(key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.for(key: Resilient::Key.new("test"))
       circuit_breaker.reset
 
       assert_equal 0, circuit_breaker.opened_or_last_checked_at_epoch

--- a/test/resilient/circuit_breaker_test.rb
+++ b/test/resilient/circuit_breaker_test.rb
@@ -11,16 +11,16 @@ module Resilient
 
     include Test::CircuitBreakerInterface
 
-    def test_new
-      first_initialization = CircuitBreaker.new(key: Resilient::Key.new("longmire"))
+    def test_for
+      first_initialization = CircuitBreaker.for(key: Resilient::Key.new("longmire"))
       assert_instance_of CircuitBreaker, first_initialization
 
-      second_initialization = CircuitBreaker.new(key: Resilient::Key.new("longmire"))
+      second_initialization = CircuitBreaker.for(key: Resilient::Key.new("longmire"))
       assert_instance_of CircuitBreaker, second_initialization
       assert first_initialization.equal?(second_initialization),
         "#{first_initialization.inspect} is not the exact same object as #{second_initialization.inspect}"
 
-      symbol_initialization = CircuitBreaker.new(key: Resilient::Key.new(:longmire))
+      symbol_initialization = CircuitBreaker.for(key: Resilient::Key.new(:longmire))
       assert_instance_of CircuitBreaker, symbol_initialization
       assert first_initialization.equal?(symbol_initialization),
         "#{first_initialization.inspect} is not the exact same object as #{symbol_initialization.inspect}"

--- a/test/resilient/circuit_breaker_test.rb
+++ b/test/resilient/circuit_breaker_test.rb
@@ -6,21 +6,21 @@ module Resilient
   class CircuitBreakerTest < Test
     def setup
       super
-      @object = CircuitBreaker.for(key: Resilient::Key.new("object"))
+      @object = CircuitBreaker.get_instance(key: Resilient::Key.new("object"))
     end
 
     include Test::CircuitBreakerInterface
 
     def test_for
-      first_initialization = CircuitBreaker.for(key: Resilient::Key.new("longmire"))
+      first_initialization = CircuitBreaker.get_instance(key: Resilient::Key.new("longmire"))
       assert_instance_of CircuitBreaker, first_initialization
 
-      second_initialization = CircuitBreaker.for(key: Resilient::Key.new("longmire"))
+      second_initialization = CircuitBreaker.get_instance(key: Resilient::Key.new("longmire"))
       assert_instance_of CircuitBreaker, second_initialization
       assert first_initialization.equal?(second_initialization),
         "#{first_initialization.inspect} is not the exact same object as #{second_initialization.inspect}"
 
-      symbol_initialization = CircuitBreaker.for(key: Resilient::Key.new(:longmire))
+      symbol_initialization = CircuitBreaker.get_instance(key: Resilient::Key.new(:longmire))
       assert_instance_of CircuitBreaker, symbol_initialization
       assert first_initialization.equal?(symbol_initialization),
         "#{first_initialization.inspect} is not the exact same object as #{symbol_initialization.inspect}"
@@ -28,17 +28,17 @@ module Resilient
 
     def test_for_with_nil_key
       assert_raises ArgumentError do
-        CircuitBreaker.for(key: nil)
+        CircuitBreaker.get_instance(key: nil)
       end
     end
 
     def test_for_with_different_properties_than_initially_provided
       key = Resilient::Key.new("longmire")
       original_properties = CircuitBreaker::Properties.new(error_threshold_percentage: 10)
-      circuit_breaker = CircuitBreaker.for(key: key, properties: original_properties)
+      circuit_breaker = CircuitBreaker.get_instance(key: key, properties: original_properties)
 
       different_properties = CircuitBreaker::Properties.new(error_threshold_percentage: 15)
-      different_properties_circuit_breaker = CircuitBreaker.for(key: key, properties: different_properties)
+      different_properties_circuit_breaker = CircuitBreaker.get_instance(key: key, properties: different_properties)
 
       assert_equal original_properties.error_threshold_percentage,
         different_properties_circuit_breaker.properties.error_threshold_percentage
@@ -58,7 +58,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new(default_test_properties_options({
         error_threshold_percentage: 51,
       }))
-      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -70,7 +70,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new(default_test_properties_options({
         error_threshold_percentage: 49,
       }))
-      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -82,7 +82,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new(default_test_properties_options({
         error_threshold_percentage: 50,
       }))
-      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -94,7 +94,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new(default_test_properties_options({
         request_volume_threshold: 5,
       }))
-      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
       4.times { circuit_breaker.metrics.failure }
 
       assert circuit_breaker.allow_request?,
@@ -107,7 +107,7 @@ module Resilient
         error_threshold_percentage: 49,
         sleep_window_seconds: 5,
       }))
-      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -145,7 +145,7 @@ module Resilient
         error_threshold_percentage: 51,
         force_open: true,
       }))
-      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -159,7 +159,7 @@ module Resilient
         request_volume_threshold: 0,
         force_closed: true,
       }))
-      circuit_breaker = CircuitBreaker.for(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -169,7 +169,7 @@ module Resilient
 
     def test_success_when_open_does_reset_metrics
       metrics = Minitest::Mock.new
-      circuit_breaker = CircuitBreaker.for(open: true, metrics: metrics, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(open: true, metrics: metrics, key: Resilient::Key.new("test"))
 
       metrics.expect :reset, nil
       circuit_breaker.success
@@ -178,7 +178,7 @@ module Resilient
 
     def test_success_when_not_open_calls_success_on_metrics
       metrics = Minitest::Mock.new
-      circuit_breaker = CircuitBreaker.for(open: false, metrics: metrics, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(open: false, metrics: metrics, key: Resilient::Key.new("test"))
 
       metrics.expect :success, nil
       circuit_breaker.success
@@ -187,7 +187,7 @@ module Resilient
 
     def test_failure_calls_failure_on_metrics
       metrics = Minitest::Mock.new
-      circuit_breaker = CircuitBreaker.for(metrics: metrics, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(metrics: metrics, key: Resilient::Key.new("test"))
 
       metrics.expect :failure, nil
       circuit_breaker.failure
@@ -196,7 +196,7 @@ module Resilient
 
     def test_reset_calls_reset_on_metrics
       metrics = Minitest::Mock.new
-      circuit_breaker = CircuitBreaker.for(metrics: metrics, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(metrics: metrics, key: Resilient::Key.new("test"))
 
       metrics.expect :reset, nil
       circuit_breaker.reset
@@ -204,14 +204,14 @@ module Resilient
     end
 
     def test_reset_sets_open_to_false
-      circuit_breaker = CircuitBreaker.for(key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(key: Resilient::Key.new("test"))
       circuit_breaker.reset
 
       assert_equal false, circuit_breaker.open
     end
 
     def test_reset_sets_opened_or_last_checked_at_epoch_to_zero
-      circuit_breaker = CircuitBreaker.for(key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get_instance(key: Resilient::Key.new("test"))
       circuit_breaker.reset
 
       assert_equal 0, circuit_breaker.opened_or_last_checked_at_epoch

--- a/test/resilient/circuit_breaker_test.rb
+++ b/test/resilient/circuit_breaker_test.rb
@@ -26,6 +26,24 @@ module Resilient
         "#{first_initialization.inspect} is not the exact same object as #{symbol_initialization.inspect}"
     end
 
+    def test_for_with_nil_key
+      assert_raises ArgumentError do
+        CircuitBreaker.for(key: nil)
+      end
+    end
+
+    def test_for_with_different_properties_than_initially_provided
+      key = Resilient::Key.new("longmire")
+      original_properties = CircuitBreaker::Properties.new(error_threshold_percentage: 10)
+      circuit_breaker = CircuitBreaker.for(key: key, properties: original_properties)
+
+      different_properties = CircuitBreaker::Properties.new(error_threshold_percentage: 15)
+      different_properties_circuit_breaker = CircuitBreaker.for(key: key, properties: different_properties)
+
+      assert_equal original_properties.error_threshold_percentage,
+        different_properties_circuit_breaker.properties.error_threshold_percentage
+    end
+
     def test_new
       assert_raises NoMethodError do
         CircuitBreaker.new(key: Resilient::Key.new("test"))

--- a/test/resilient/circuit_breaker_test.rb
+++ b/test/resilient/circuit_breaker_test.rb
@@ -5,10 +5,23 @@ require "resilient/test/circuit_breaker_interface"
 module Resilient
   class CircuitBreakerTest < Resilient::Test
     def setup
+      super
       @object = CircuitBreaker.new(key: Resilient::Key.new("test"))
     end
 
     include Test::CircuitBreakerInterface
+
+    def test_new
+      key = Resilient::Key.new("longmire")
+      first_initialization = CircuitBreaker.new(key: key)
+      assert_instance_of CircuitBreaker, first_initialization
+
+      second_initialization = CircuitBreaker.new(key: key)
+      assert_instance_of CircuitBreaker, second_initialization
+
+      assert first_initialization.equal?(second_initialization),
+        "#{first_initialization.inspect} is not the exact same object as #{second_initialization.inspect}"
+    end
 
     def test_key
       assert_equal "test", @object.key.name

--- a/test/resilient/instrumenters/memory_test.rb
+++ b/test/resilient/instrumenters/memory_test.rb
@@ -3,7 +3,7 @@ require "resilient/instrumenters/memory"
 
 module Resilient
   module Instrumenters
-    class MemoryTest < Resilient::Test
+    class MemoryTest < Test
       def test_initialize
         instrumenter = Memory.new
         assert_equal [], instrumenter.events

--- a/test/resilient/instrumenters/noop_test.rb
+++ b/test/resilient/instrumenters/noop_test.rb
@@ -3,7 +3,7 @@ require "resilient/instrumenters/noop"
 
 module Resilient
   module Instrumenters
-    class NoopTest < Resilient::Test
+    class NoopTest < Test
       def test_instrument_with_name
         yielded = false
         Noop.instrument(:foo) { yielded = true }

--- a/test/resilient/key_test.rb
+++ b/test/resilient/key_test.rb
@@ -3,7 +3,7 @@ require "resilient/circuit_breaker"
 require "resilient/test/circuit_breaker_interface"
 
 module Resilient
-  class CircuitBreakerTest < Resilient::Test
+  class KeyTest < Resilient::Test
     def test_initialize_with_string
       key = Key.new("test")
       assert_equal "test", key.name

--- a/test/resilient/key_test.rb
+++ b/test/resilient/key_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+require "resilient/circuit_breaker"
+require "resilient/test/circuit_breaker_interface"
+
+module Resilient
+  class CircuitBreakerTest < Resilient::Test
+    def test_initialize_with_string
+      key = Key.new("test")
+      assert_equal "test", key.name
+    end
+
+    def test_initialize_with_symbol
+      key = Key.new(:test)
+      assert_equal "test", key.name
+    end
+
+    def test_hash
+      name = "test"
+      key = Key.new(name)
+      assert_equal name.hash, key.hash
+    end
+
+    def test_equality
+      key_a = Key.new("a")
+      key_b = Key.new("b")
+      other_key_a = Key.new("a")
+      not_key = Object.new
+
+      assert key_a.eql?(other_key_a)
+      refute key_a.eql?(not_key)
+      refute key_a.eql?(key_b)
+
+      assert key_a == other_key_a
+      refute key_a == not_key
+      refute key_a == key_b
+    end
+
+    def test_as_hash_key
+      key_a = Key.new("a")
+      key_b = Key.new("b")
+      other_key_a = Key.new("a")
+      hash = {}
+      hash[key_a] = "a"
+      hash[other_key_a] = "other_a"
+      hash[key_b] = "b"
+
+      assert_equal "other_a", hash[key_a]
+      assert_equal "other_a", hash[other_key_a]
+      assert_equal "b", hash[key_b]
+    end
+  end
+end

--- a/test/resilient/key_test.rb
+++ b/test/resilient/key_test.rb
@@ -3,7 +3,7 @@ require "resilient/circuit_breaker"
 require "resilient/test/circuit_breaker_interface"
 
 module Resilient
-  class KeyTest < Resilient::Test
+  class KeyTest < Test
     def test_initialize_with_string
       key = Key.new("test")
       assert_equal "test", key.name

--- a/test/resilient_test.rb
+++ b/test/resilient_test.rb
@@ -1,8 +1,10 @@
 require "test_helper"
 require "resilient"
 
-class ResilientTest < Resilient::Test
-  def test_that_it_has_a_version_number
-    refute_nil Resilient::VERSION
+module Resilient
+  class ResilientTest < Test
+    def test_that_it_has_a_version_number
+      refute_nil Resilient::VERSION
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,10 @@ require "pathname"
 
 module Resilient
   class Test < Minitest::Test
+    def setup
+      CircuitBreaker.reset
+    end
+
     def debug_metrics(metrics, indent: "")
       keys = [:success, :failure]
       result = Hash.new { |h, k| h[k] = Hash.new(0) }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,10 @@ require "pathname"
 module Resilient
   class Test < Minitest::Test
     def setup
-      CircuitBreaker.reset
+      # Fully wipe out all circuit breakers before every test since all of these
+      # circuits are temporary. You don't want to do this in your test suite.
+      # Use CircuitBreaker.reset as directed in the readme.
+      CircuitBreaker::Registry.default = CircuitBreaker::Registry.new
     end
 
     def debug_metrics(metrics, indent: "")


### PR DESCRIPTION
## Problems

1. Remembering to reset circuits in the test environment for every circuit breaker gets tedious. 
2. If your circuit is in an ivar for an instance of some service/thing being protected and you create a new instance of service/thing, your new instance is not protected by the same circuit unless you keep register them yourself somewhere and ensure that you are returning the same instance.

```ruby
class MyService
  def initialize
    key = Resilient::Key.new("my-service")
    @circuit_breaker = Resilient::CircuitBreaker.new(key: key)
  end
end

service = MyService.new

# this has a different circuit breaker instance and state/metrics 
# than the first unless you keep track of it somewhere; with this
# PR, it will have the same instance so no extra work for you
another_instance = MyService.new
```

## Solution

key is unique to the circuit, so we might as well use that to register instances of circuit breakers and ensure that only one instance per circuit is created for a process, which solves 2 above. Having all the instances means we can easily reset between tests, which solves 1 above.

You can now do:

```ruby
key = Resilient::Key.new("whatever")

# as many times as you want and you get the same object in memory
Resilient::CircuitBreaker.new(key: key)

# you can also do this as many times as you want (with new key instance 
# but matching key name) and you get the same instances as above
Resilient::CircuitBreaker.new(key: Resilient::Key.new("whatever"))

# and this will clear the registry for tests, which means calling new again returns 
# a new instance with clean state/metrics; old instances can just get GC'd 
# eventually whenever ruby wants
Resilient::CircuitBreaker.reset
```

I'm not sure if `@source.clear` or `@source = {}` would be best in `Registry#reset`, but I went with `clear` for now. 

## Notes

The implementation is not thread safe, but neither is the circuit breaker currently. Because I made the registry have a restricted interface (`fetch` and `reset` instead of a liberal hash), making a ThreadSafeCircuitBraker and ThreadSafeCircuitBreaker::Registry should be pretty easy.

cc @aroben for review as we talked about doing this
cc @jbarnette as you recently helped with circuits and I'd be curious if you have any thoughts here, if you don't have time, no problem
fyi @joshvera as I had you store a circuit in a class var, we can remove that once this ships, nothing for you to do, just making you aware