### PR TITLE
Initialize Convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ require "resilient/circuit_breaker"
 # creating multiple instances of the same circuit breaker for a key; not using
 # `for` means you would have multiple instances of the circuit breaker and thus
 # separate state and metrics; you can read more in examples/for_vs_new.rb
-circuit_breaker = Resilient::CircuitBreaker.get(key: Resilient::Key.new("example"))
+circuit_breaker = Resilient::CircuitBreaker.get("example")
 if circuit_breaker.allow_request?
   begin
     # do something expensive
@@ -55,7 +55,7 @@ properties = Resilient::CircuitBreaker::Properties.new({
   # do not open circuit until at least 5 requests have happened
   request_volume_threshold: 5,
 })
-circuit_breaker = Resilient::CircuitBreaker.get(properties: properties, key: Resilient::Key.new("example"))
+circuit_breaker = Resilient::CircuitBreaker.get("example", properties: properties)
 # etc etc etc
 ```
 
@@ -63,7 +63,7 @@ force the circuit to be always open:
 
 ```ruby
 properties = Resilient::CircuitBreaker::Properties.new(force_open: true)
-circuit_breaker = Resilient::CircuitBreaker.get(properties: properties, key: Resilient::Key.new("example"))
+circuit_breaker = Resilient::CircuitBreaker.get("example", properties: properties)
 # etc etc etc
 ```
 
@@ -71,7 +71,7 @@ force the circuit to be always closed (great way to test in production with no i
 
 ```ruby
 properties = Resilient::CircuitBreaker::Properties.new(force_closed: true)
-circuit_breaker = Resilient::CircuitBreaker.get(properties: properties, key: Resilient::Key.new("example"))
+circuit_breaker = Resilient::CircuitBreaker.get("example", properties: properties)
 # etc etc etc
 ```
 
@@ -82,7 +82,7 @@ metrics = Resilient::CircuitBreaker::Metrics.new({
   window_size_in_seconds: 10,
   bucket_size_in_seconds: 1,
 })
-circuit_breaker = Resilient::CircuitBreaker.get(metrics: metrics, key: Resilient::Key.new("example"))
+circuit_breaker = Resilient::CircuitBreaker.get("example", metrics: metrics)
 # etc etc etc
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ end
 customize properties of circuit:
 
 ```ruby
-properties = Resilient::CircuitBreaker::Properties.new({
+circuit_breaker = Resilient::CircuitBreaker.get("example", {
   # at what percentage of errors should we open the circuit
   error_threshold_percentage: 50,
   # do not try request again for 5 seconds
@@ -55,34 +55,30 @@ properties = Resilient::CircuitBreaker::Properties.new({
   # do not open circuit until at least 5 requests have happened
   request_volume_threshold: 5,
 })
-circuit_breaker = Resilient::CircuitBreaker.get("example", properties: properties)
 # etc etc etc
 ```
 
 force the circuit to be always open:
 
 ```ruby
-properties = Resilient::CircuitBreaker::Properties.new(force_open: true)
-circuit_breaker = Resilient::CircuitBreaker.get("example", properties: properties)
+circuit_breaker = Resilient::CircuitBreaker.get("example", force_open: true)
 # etc etc etc
 ```
 
 force the circuit to be always closed (great way to test in production with no impact, all instrumentation still runs which means you can measure in production with config and gain confidence while never actually opening a circuit incorrectly):
 
 ```ruby
-properties = Resilient::CircuitBreaker::Properties.new(force_closed: true)
-circuit_breaker = Resilient::CircuitBreaker.get("example", properties: properties)
+circuit_breaker = Resilient::CircuitBreaker.get("example", force_closed: true)
 # etc etc etc
 ```
 
 customize rolling window to be 10 buckets of 1 second each (10 seconds in all):
 
 ```ruby
-metrics = Resilient::CircuitBreaker::Metrics.new({
+circuit_breaker = Resilient::CircuitBreaker.get("example", {
   window_size_in_seconds: 10,
   bucket_size_in_seconds: 1,
 })
-circuit_breaker = Resilient::CircuitBreaker.get("example", metrics: metrics)
 # etc etc etc
 ```
 

--- a/examples/basic.rb
+++ b/examples/basic.rb
@@ -8,12 +8,11 @@ $:.unshift(lib_path)
 require "pp"
 require "resilient/circuit_breaker"
 
-properties = Resilient::CircuitBreaker::Properties.new({
+circuit_breaker = Resilient::CircuitBreaker.get("example", {
   sleep_window_seconds: 1,
   request_volume_threshold: 10,
   error_threshold_percentage: 25,
 })
-circuit_breaker = Resilient::CircuitBreaker.get("example", properties: properties)
 
 # success
 if circuit_breaker.allow_request?

--- a/examples/basic.rb
+++ b/examples/basic.rb
@@ -13,7 +13,7 @@ properties = Resilient::CircuitBreaker::Properties.new({
   request_volume_threshold: 10,
   error_threshold_percentage: 25,
 })
-circuit_breaker = Resilient::CircuitBreaker.get(key: Resilient::Key.new("example"), properties: properties)
+circuit_breaker = Resilient::CircuitBreaker.get("example", properties: properties)
 
 # success
 if circuit_breaker.allow_request?

--- a/examples/get_vs_new.rb
+++ b/examples/get_vs_new.rb
@@ -12,10 +12,9 @@ ENV["RESILIENT_PUBLICIZE_NEW"] = "1"
 require "pp"
 require "resilient/circuit_breaker"
 
-key = Resilient::Key.new("example")
-instance = Resilient::CircuitBreaker.get(key: key)
-instance_using_get = Resilient::CircuitBreaker.get(key: key)
-instance_using_new = Resilient::CircuitBreaker.new(key: key)
+instance = Resilient::CircuitBreaker.get("example")
+instance_using_get = Resilient::CircuitBreaker.get("example")
+instance_using_new = Resilient::CircuitBreaker.new("example")
 
 puts "instance equals instance_using_get: #{instance.equal?(instance_using_get)}"
 puts "instance equals instance_using_new: #{instance.equal?(instance_using_new)}"

--- a/examples/long_running.rb
+++ b/examples/long_running.rb
@@ -15,7 +15,7 @@ properties = Resilient::CircuitBreaker::Properties.new({
   window_size_in_seconds: 60,
   bucket_size_in_seconds: 1,
 })
-circuit_breaker = Resilient::CircuitBreaker.get(key: Resilient::Key.new("example"), properties: properties)
+circuit_breaker = Resilient::CircuitBreaker.get("example", properties: properties)
 
 iterations = 0
 loop do

--- a/examples/long_running.rb
+++ b/examples/long_running.rb
@@ -8,14 +8,13 @@ $:.unshift(lib_path)
 require "pp"
 require "resilient/circuit_breaker"
 
-properties = Resilient::CircuitBreaker::Properties.new({
+circuit_breaker = Resilient::CircuitBreaker.get("example", {
   sleep_window_seconds: 5,
   request_volume_threshold: 20,
   error_threshold_percentage: 10,
   window_size_in_seconds: 60,
   bucket_size_in_seconds: 1,
 })
-circuit_breaker = Resilient::CircuitBreaker.get("example", properties: properties)
 
 iterations = 0
 loop do

--- a/lib/resilient/circuit_breaker.rb
+++ b/lib/resilient/circuit_breaker.rb
@@ -18,6 +18,7 @@ module Resilient
     # allocating a new instance in order to ensure that state/metrics are the
     # same per key.
     def self.get(key: nil, open: false, properties: nil, metrics: nil, registry: nil)
+      key = Key.wrap(key) unless key.nil?
       (registry || Registry.default).fetch(key) {
         new(key: key, open: open, properties: properties, metrics: metrics)
       }
@@ -38,7 +39,8 @@ module Resilient
     def initialize(key: nil, open: false, properties: nil, metrics: nil)
       # ruby 2.0 does not support required keyword arguments, this gets around that
       raise ArgumentError, "key argument is required" if key.nil?
-      @key = key
+
+      @key = Key.wrap(key)
       @open = open
       @opened_or_last_checked_at_epoch = 0
 

--- a/lib/resilient/circuit_breaker.rb
+++ b/lib/resilient/circuit_breaker.rb
@@ -17,10 +17,10 @@ module Resilient
     # registered. If key does exist, it returns registered instance instead of
     # allocating a new instance in order to ensure that state/metrics are the
     # same per key.
-    def self.get(key: nil, open: false, properties: nil, metrics: nil, registry: nil)
+    def self.get(key: nil, properties: nil, metrics: nil, registry: nil)
       key = Key.wrap(key) unless key.nil?
       (registry || Registry.default).fetch(key) {
-        new(key: key, open: open, properties: properties, metrics: metrics)
+        new(key: key, properties: properties, metrics: metrics)
       }
     end
 
@@ -36,12 +36,12 @@ module Resilient
     attr_reader :metrics
     attr_reader :properties
 
-    def initialize(key: nil, open: false, properties: nil, metrics: nil)
+    def initialize(key: nil, properties: nil, metrics: nil)
       # ruby 2.0 does not support required keyword arguments, this gets around that
       raise ArgumentError, "key argument is required" if key.nil?
 
       @key = Key.wrap(key)
-      @open = open
+      @open = false
       @opened_or_last_checked_at_epoch = 0
 
       @properties = if properties

--- a/lib/resilient/circuit_breaker.rb
+++ b/lib/resilient/circuit_breaker.rb
@@ -17,6 +17,8 @@ module Resilient
     # registered. If key does exist, it returns registered instance instead of
     # allocating a new instance in order to ensure that state/metrics are the
     # same per key.
+    #
+    #  See #initialize for docs on key, properties and metrics.
     def self.get(key: nil, properties: nil, metrics: nil, registry: nil)
       key = Key.wrap(key) unless key.nil?
       (registry || Registry.default).fetch(key) {
@@ -37,6 +39,20 @@ module Resilient
     attr_reader :metrics
     attr_reader :properties
 
+    # Private: Builds new instance of a CircuitBreaker.
+    #
+    #  key - The String or Resilient::Key that determines uniqueness of the
+    #        circuit breaker in the registry and for instrumentation.
+    #
+    #  properties - The Hash or Resilient::CircuitBreaker::Properties that determine how the
+    #               circuit breaker should behave. Optional. Defaults to new
+    #               Resilient::CircuitBreaker::Properties instance.
+    #
+    #  metrics - The object that stores successes and failures. Optional.
+    #            Defaults to new Resilient::CircuitBreaker::Metrics instance
+    #            based on window size and bucket size properties.
+    #
+    # Returns CircuitBreaker instance.
     def initialize(key: nil, properties: nil, metrics: nil)
       # ruby 2.0 does not support required keyword arguments, this gets around that
       raise ArgumentError, "key argument is required" if key.nil?

--- a/lib/resilient/circuit_breaker.rb
+++ b/lib/resilient/circuit_breaker.rb
@@ -19,10 +19,10 @@ module Resilient
     # same per key.
     #
     #  See #initialize for docs on key, properties and metrics.
-    def self.get(key, properties: nil, metrics: nil, registry: nil)
+    def self.get(key, properties = nil, metrics = nil, registry = nil)
       key = Key.wrap(key)
       (registry || Registry.default).fetch(key) {
-        new(key, properties: properties, metrics: metrics)
+        new(key, properties, metrics)
       }
     end
 
@@ -53,7 +53,7 @@ module Resilient
     #            based on window size and bucket size properties.
     #
     # Returns CircuitBreaker instance.
-    def initialize(key, properties: nil, metrics: nil)
+    def initialize(key, properties = nil, metrics = nil)
       raise ArgumentError, "key argument is required" if key.nil?
 
       @key = Key.wrap(key)

--- a/lib/resilient/circuit_breaker.rb
+++ b/lib/resilient/circuit_breaker.rb
@@ -27,6 +27,7 @@ module Resilient
     unless ENV.key?("RESILIENT_PUBLICIZE_NEW")
       class << self
         private :new
+        private :allocate
       end
     end
 

--- a/lib/resilient/circuit_breaker.rb
+++ b/lib/resilient/circuit_breaker.rb
@@ -45,7 +45,7 @@ module Resilient
       @opened_or_last_checked_at_epoch = 0
 
       @properties = if properties
-        properties
+        Properties.wrap(properties)
       else
         Properties.new
       end

--- a/lib/resilient/circuit_breaker.rb
+++ b/lib/resilient/circuit_breaker.rb
@@ -20,7 +20,7 @@ module Resilient
     #
     #  See #initialize for docs on key, properties and metrics.
     def self.get(key: nil, properties: nil, metrics: nil, registry: nil)
-      key = Key.wrap(key) unless key.nil?
+      key = Key.wrap(key)
       (registry || Registry.default).fetch(key) {
         new(key: key, properties: properties, metrics: metrics)
       }

--- a/lib/resilient/circuit_breaker.rb
+++ b/lib/resilient/circuit_breaker.rb
@@ -19,10 +19,10 @@ module Resilient
     # same per key.
     #
     #  See #initialize for docs on key, properties and metrics.
-    def self.get(key: nil, properties: nil, metrics: nil, registry: nil)
+    def self.get(key, properties: nil, metrics: nil, registry: nil)
       key = Key.wrap(key)
       (registry || Registry.default).fetch(key) {
-        new(key: key, properties: properties, metrics: metrics)
+        new(key, properties: properties, metrics: metrics)
       }
     end
 
@@ -53,8 +53,7 @@ module Resilient
     #            based on window size and bucket size properties.
     #
     # Returns CircuitBreaker instance.
-    def initialize(key: nil, properties: nil, metrics: nil)
-      # ruby 2.0 does not support required keyword arguments, this gets around that
+    def initialize(key, properties: nil, metrics: nil)
       raise ArgumentError, "key argument is required" if key.nil?
 
       @key = Key.wrap(key)

--- a/lib/resilient/circuit_breaker/properties.rb
+++ b/lib/resilient/circuit_breaker/properties.rb
@@ -3,6 +3,17 @@ require "resilient/instrumenters/noop"
 module Resilient
   class CircuitBreaker
     class Properties
+
+      # Internal: Takes a string name or instance of a Key and always returns a
+      # Key instance.
+      def self.wrap(hash_or_instance)
+        if hash_or_instance.is_a?(self)
+          hash_or_instance
+        else
+          new(hash_or_instance)
+        end
+      end
+
       # allows forcing the circuit open (stopping all requests)
       attr_reader :force_open
 

--- a/lib/resilient/circuit_breaker/properties.rb
+++ b/lib/resilient/circuit_breaker/properties.rb
@@ -7,10 +7,13 @@ module Resilient
       # Internal: Takes a string name or instance of a Key and always returns a
       # Key instance.
       def self.wrap(hash_or_instance)
-        if hash_or_instance.is_a?(self)
+        case hash_or_instance
+        when self
           hash_or_instance
-        else
+        when Hash
           new(hash_or_instance)
+        else
+          raise TypeError, "properties must be Hash or Resilient::Properties instance"
         end
       end
 

--- a/lib/resilient/key.rb
+++ b/lib/resilient/key.rb
@@ -3,11 +3,12 @@ module Resilient
 
     # Internal: Takes a string name or instance of a Key and always returns a
     # Key instance.
-    def self.wrap(name_or_instance)
-      if name_or_instance.is_a?(self)
-        name_or_instance
+    def self.wrap(string_or_instance)
+      case string_or_instance
+      when self
+        string_or_instance
       else
-        new(name_or_instance)
+        new(string_or_instance)
       end
     end
 

--- a/lib/resilient/key.rb
+++ b/lib/resilient/key.rb
@@ -1,5 +1,16 @@
 module Resilient
   class Key
+
+    # Internal: Takes a string name or instance of a Key and always returns a
+    # Key instance.
+    def self.wrap(name_or_instance)
+      if name_or_instance.is_a?(self)
+        name_or_instance
+      else
+        new(name_or_instance)
+      end
+    end
+
     attr_reader :name
 
     def initialize(name)

--- a/lib/resilient/key.rb
+++ b/lib/resilient/key.rb
@@ -14,7 +14,8 @@ module Resilient
     attr_reader :name
 
     def initialize(name)
-      @name = name.to_s
+      raise TypeError, "name must be a String" unless name.is_a?(String)
+      @name = name
     end
 
     def ==(other)

--- a/lib/resilient/key.rb
+++ b/lib/resilient/key.rb
@@ -5,7 +5,7 @@ module Resilient
     # Key instance.
     def self.wrap(string_or_instance)
       case string_or_instance
-      when self
+      when self, NilClass
         string_or_instance
       else
         new(string_or_instance)

--- a/test/resilient/circuit_breaker/properties_test.rb
+++ b/test/resilient/circuit_breaker/properties_test.rb
@@ -27,6 +27,12 @@ module Resilient
         assert_equal original_properties.force_open, properties.force_open
       end
 
+      def test_wrap_with_unsupported_type
+        assert_raises TypeError do
+          Properties.wrap(Object.new)
+        end
+      end
+
       def test_defaults_force_open
         assert_equal false, @object.force_open
       end

--- a/test/resilient/circuit_breaker/properties_test.rb
+++ b/test/resilient/circuit_breaker/properties_test.rb
@@ -14,6 +14,19 @@ module Resilient
 
       include Test::PropertiesInterface
 
+      def test_wrap_with_hash
+        properties = Properties.wrap(force_open: true)
+        assert_instance_of Properties, properties
+        assert properties.force_open
+      end
+
+      def test_wrap_with_instance
+        original_properties = Properties.new(force_open: true)
+        properties = Properties.wrap(original_properties)
+        assert_instance_of Properties, properties
+        assert_equal original_properties.force_open, properties.force_open
+      end
+
       def test_defaults_force_open
         assert_equal false, @object.force_open
       end

--- a/test/resilient/circuit_breaker_instrumentation_test.rb
+++ b/test/resilient/circuit_breaker_instrumentation_test.rb
@@ -11,7 +11,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new({
         instrumenter: instrumenter,
       })
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       assert circuit_breaker.allow_request?
       event = instrumenter.events.detect { |event| event.name =~ /allow_request/ }
       refute_nil event
@@ -35,7 +35,7 @@ module Resilient
         instrumenter: instrumenter,
         force_open: true,
       })
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       refute circuit_breaker.allow_request?
       event = instrumenter.events.first
       refute_nil event
@@ -54,7 +54,7 @@ module Resilient
         instrumenter: instrumenter,
         force_closed: true,
       })
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       assert circuit_breaker.allow_request?
       event = instrumenter.events.detect { |event| event.name =~ /allow_request/ }
       refute_nil event
@@ -79,7 +79,7 @@ module Resilient
         error_threshold_percentage: 50,
         request_volume_threshold: 0,
       })
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       circuit_breaker.failure
       assert circuit_breaker.allow_request?
       event = instrumenter.events.detect { |event|
@@ -112,7 +112,7 @@ module Resilient
         request_volume_threshold: 0,
         sleep_window_seconds: 1,
       })
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       circuit_breaker.failure
       assert circuit_breaker.allow_request?
 
@@ -149,7 +149,7 @@ module Resilient
         error_threshold_percentage: 50,
         request_volume_threshold: 0,
       })
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       circuit_breaker.properties.instrumenter.reset
       circuit_breaker.failure
       refute circuit_breaker.allow_request?
@@ -182,7 +182,7 @@ module Resilient
         request_volume_threshold: 0,
         sleep_window_seconds: 1,
       })
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       circuit_breaker.failure
       refute circuit_breaker.allow_request?
 
@@ -217,7 +217,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new({
         instrumenter: instrumenter,
       })
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       circuit_breaker.success
       event = instrumenter.events.first
       refute_nil event
@@ -231,7 +231,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new({
         instrumenter: instrumenter,
       })
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       circuit_breaker.instance_variable_set("@open", true)
       circuit_breaker.success
       event = instrumenter.events.first
@@ -246,7 +246,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new({
         instrumenter: instrumenter,
       })
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       circuit_breaker.failure
       event = instrumenter.events.first
       refute_nil event
@@ -259,7 +259,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new({
         instrumenter: instrumenter,
       })
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       circuit_breaker.reset
       event = instrumenter.events.first
       refute_nil event

--- a/test/resilient/circuit_breaker_instrumentation_test.rb
+++ b/test/resilient/circuit_breaker_instrumentation_test.rb
@@ -217,7 +217,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new({
         instrumenter: instrumenter,
       })
-      circuit_breaker = CircuitBreaker.get(open: false, properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
       circuit_breaker.success
       event = instrumenter.events.first
       refute_nil event
@@ -231,7 +231,8 @@ module Resilient
       properties = CircuitBreaker::Properties.new({
         instrumenter: instrumenter,
       })
-      circuit_breaker = CircuitBreaker.get(open: true, properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker.instance_variable_set("@open", true)
       circuit_breaker.success
       event = instrumenter.events.first
       refute_nil event

--- a/test/resilient/circuit_breaker_instrumentation_test.rb
+++ b/test/resilient/circuit_breaker_instrumentation_test.rb
@@ -8,10 +8,7 @@ module Resilient
   class CircuitBreakerInstrumentationTest < Test
     def test_instruments_allow_request
       instrumenter = Instrumenters::Memory.new
-      properties = CircuitBreaker::Properties.new({
-        instrumenter: instrumenter,
-      })
-      circuit_breaker = CircuitBreaker.get("test", properties: properties)
+      circuit_breaker = CircuitBreaker.get("test", instrumenter: instrumenter)
       assert circuit_breaker.allow_request?
       event = instrumenter.events.detect { |event| event.name =~ /allow_request/ }
       refute_nil event
@@ -31,11 +28,10 @@ module Resilient
 
     def test_instruments_allow_request_force_open
       instrumenter = Instrumenters::Memory.new
-      properties = CircuitBreaker::Properties.new({
+      circuit_breaker = CircuitBreaker.get("test", {
         instrumenter: instrumenter,
         force_open: true,
       })
-      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       refute circuit_breaker.allow_request?
       event = instrumenter.events.first
       refute_nil event
@@ -50,11 +46,10 @@ module Resilient
 
     def test_instruments_allow_request_force_closed
       instrumenter = Instrumenters::Memory.new
-      properties = CircuitBreaker::Properties.new({
+      circuit_breaker = CircuitBreaker.get("test", {
         instrumenter: instrumenter,
         force_closed: true,
       })
-      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       assert circuit_breaker.allow_request?
       event = instrumenter.events.detect { |event| event.name =~ /allow_request/ }
       refute_nil event
@@ -73,13 +68,12 @@ module Resilient
 
     def test_instruments_allow_request_force_closed_when_normal_behavior_would_be_open
       instrumenter = Instrumenters::Memory.new
-      properties = CircuitBreaker::Properties.new({
+      circuit_breaker = CircuitBreaker.get("test", {
         instrumenter: instrumenter,
         force_closed: true,
         error_threshold_percentage: 50,
         request_volume_threshold: 0,
       })
-      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       circuit_breaker.failure
       assert circuit_breaker.allow_request?
       event = instrumenter.events.detect { |event|
@@ -105,19 +99,18 @@ module Resilient
 
     def test_instrument_allow_request_force_closed_when_normal_behavior_would_be_allow_single_request
       instrumenter = Instrumenters::Memory.new
-      properties = CircuitBreaker::Properties.new({
+      circuit_breaker = CircuitBreaker.get("test", {
         instrumenter: instrumenter,
         force_closed: true,
         error_threshold_percentage: 50,
         request_volume_threshold: 0,
         sleep_window_seconds: 1,
       })
-      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       circuit_breaker.failure
       assert circuit_breaker.allow_request?
 
       # force code path through allow single request by moving past sleep threshold
-      Timecop.freeze(Time.now + properties.sleep_window_seconds + 1) {
+      Timecop.freeze(Time.now + circuit_breaker.properties.sleep_window_seconds + 1) {
         assert circuit_breaker.allow_request?
       }
 
@@ -144,12 +137,11 @@ module Resilient
 
     def test_instruments_allow_request_open_true_allow_single_request_false
       instrumenter = Instrumenters::Memory.new
-      properties = CircuitBreaker::Properties.new({
+      circuit_breaker = CircuitBreaker.get("test", {
         instrumenter: instrumenter,
         error_threshold_percentage: 50,
         request_volume_threshold: 0,
       })
-      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       circuit_breaker.properties.instrumenter.reset
       circuit_breaker.failure
       refute circuit_breaker.allow_request?
@@ -176,18 +168,17 @@ module Resilient
 
     def test_instruments_allow_request_open_true_allow_single_request_true
       instrumenter = Instrumenters::Memory.new
-      properties = CircuitBreaker::Properties.new({
+      circuit_breaker = CircuitBreaker.get("test", {
         instrumenter: instrumenter,
         error_threshold_percentage: 50,
         request_volume_threshold: 0,
         sleep_window_seconds: 1,
       })
-      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       circuit_breaker.failure
       refute circuit_breaker.allow_request?
 
       # force code path through allow single request by moving past sleep threshold
-      Timecop.freeze(Time.now + properties.sleep_window_seconds + 1) {
+      Timecop.freeze(Time.now + circuit_breaker.properties.sleep_window_seconds + 1) {
         assert circuit_breaker.allow_request?
       }
 
@@ -214,10 +205,7 @@ module Resilient
 
     def test_instruments_success_when_circuit_closed
       instrumenter = Instrumenters::Memory.new
-      properties = CircuitBreaker::Properties.new({
-        instrumenter: instrumenter,
-      })
-      circuit_breaker = CircuitBreaker.get("test", properties: properties)
+      circuit_breaker = CircuitBreaker.get("test", instrumenter: instrumenter)
       circuit_breaker.success
       event = instrumenter.events.first
       refute_nil event
@@ -228,10 +216,7 @@ module Resilient
 
     def test_instruments_success_when_circuit_open
       instrumenter = Instrumenters::Memory.new
-      properties = CircuitBreaker::Properties.new({
-        instrumenter: instrumenter,
-      })
-      circuit_breaker = CircuitBreaker.get("test", properties: properties)
+      circuit_breaker = CircuitBreaker.get("test", instrumenter: instrumenter)
       circuit_breaker.instance_variable_set("@open", true)
       circuit_breaker.success
       event = instrumenter.events.first
@@ -243,10 +228,7 @@ module Resilient
 
     def test_instruments_failure
       instrumenter = Instrumenters::Memory.new
-      properties = CircuitBreaker::Properties.new({
-        instrumenter: instrumenter,
-      })
-      circuit_breaker = CircuitBreaker.get("test", properties: properties)
+      circuit_breaker = CircuitBreaker.get("test", instrumenter: instrumenter)
       circuit_breaker.failure
       event = instrumenter.events.first
       refute_nil event
@@ -256,10 +238,7 @@ module Resilient
 
     def test_instruments_reset
       instrumenter = Instrumenters::Memory.new
-      properties = CircuitBreaker::Properties.new({
-        instrumenter: instrumenter,
-      })
-      circuit_breaker = CircuitBreaker.get("test", properties: properties)
+      circuit_breaker = CircuitBreaker.get("test", instrumenter: instrumenter)
       circuit_breaker.reset
       event = instrumenter.events.first
       refute_nil event

--- a/test/resilient/circuit_breaker_integration_test.rb
+++ b/test/resilient/circuit_breaker_integration_test.rb
@@ -10,7 +10,7 @@ module Resilient
         window_size_in_seconds: 60,
         bucket_size_in_seconds: 10,
       })
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       70.times { circuit_breaker.success }
       assert circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
@@ -35,7 +35,7 @@ module Resilient
         window_size_in_seconds: 60,
         bucket_size_in_seconds: 10,
       })
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       18.times { circuit_breaker.failure }
       assert circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
@@ -51,7 +51,7 @@ module Resilient
         request_volume_threshold: 0,
         force_open: true,
       })
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       refute circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
 
@@ -66,7 +66,7 @@ module Resilient
         request_volume_threshold: 0,
         force_closed: true,
       })
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       assert circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
 
@@ -81,7 +81,7 @@ module Resilient
         force_closed: true,
         force_open: true,
       })
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       refute circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
     end
@@ -93,7 +93,7 @@ module Resilient
         window_size_in_seconds: 60,
         bucket_size_in_seconds: 10,
       })
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       now = Time.now
       bucket1 = now
       bucket2 = now + 10

--- a/test/resilient/circuit_breaker_integration_test.rb
+++ b/test/resilient/circuit_breaker_integration_test.rb
@@ -4,13 +4,12 @@ require "resilient/circuit_breaker"
 module Resilient
   class CircuitBreakerIntegrationTest < Test
     def test_enough_failures_in_time_window_open_circuit
-      properties = CircuitBreaker::Properties.new({
+      circuit_breaker = CircuitBreaker.get("test", {
         error_threshold_percentage: 25,
         request_volume_threshold: 0,
         window_size_in_seconds: 60,
         bucket_size_in_seconds: 10,
       })
-      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       70.times { circuit_breaker.success }
       assert circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
@@ -29,13 +28,12 @@ module Resilient
     end
 
     def test_enough_failures_in_time_window_but_under_request_threshold_does_not_open_circuit
-      properties = CircuitBreaker::Properties.new({
+      circuit_breaker = CircuitBreaker.get("test", {
         error_threshold_percentage: 25,
         request_volume_threshold: 20,
         window_size_in_seconds: 60,
         bucket_size_in_seconds: 10,
       })
-      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       18.times { circuit_breaker.failure }
       assert circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
@@ -46,12 +44,11 @@ module Resilient
     end
 
     def test_forced_open_does_not_allow_request_even_if_all_successes
-      properties = CircuitBreaker::Properties.new({
+      circuit_breaker = CircuitBreaker.get("test", {
         error_threshold_percentage: 25,
         request_volume_threshold: 0,
         force_open: true,
       })
-      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       refute circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
 
@@ -61,12 +58,11 @@ module Resilient
     end
 
     def test_forced_close_allows_requests_even_if_all_failures
-      properties = CircuitBreaker::Properties.new({
+      circuit_breaker = CircuitBreaker.get("test", {
         error_threshold_percentage: 25,
         request_volume_threshold: 0,
         force_closed: true,
       })
-      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       assert circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
 
@@ -76,24 +72,22 @@ module Resilient
     end
 
     def test_force_open_takes_precedence_over_force_closed
-      properties = CircuitBreaker::Properties.new({
+      circuit_breaker = CircuitBreaker.get("test", {
         request_volume_threshold: 0,
         force_closed: true,
         force_open: true,
       })
-      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       refute circuit_breaker.allow_request?,
         debug_circuit_breaker(circuit_breaker)
     end
 
     def test_allow_request_denies_for_sleep_seconds_then_allows_single_request_which_if_successful_closes_circuit
-      properties = CircuitBreaker::Properties.new({
+      circuit_breaker = CircuitBreaker.get("test", {
         error_threshold_percentage: 25,
         request_volume_threshold: 0,
         window_size_in_seconds: 60,
         bucket_size_in_seconds: 10,
       })
-      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       now = Time.now
       bucket1 = now
       bucket2 = now + 10
@@ -145,7 +139,7 @@ module Resilient
       end
 
       # single request is allowed now
-      Timecop.freeze(bucket6 + properties.sleep_window_seconds + 1) do
+      Timecop.freeze(bucket6 + circuit_breaker.properties.sleep_window_seconds + 1) do
         # allow single request through
         assert circuit_breaker.allow_request?,
           debug_circuit_breaker(circuit_breaker)

--- a/test/resilient/circuit_breaker_test.rb
+++ b/test/resilient/circuit_breaker_test.rb
@@ -32,6 +32,18 @@ module Resilient
       end
     end
 
+    def test_get_with_properties_hash
+      circuit_breaker = CircuitBreaker.get(key: "test", properties: {error_threshold_percentage: 51})
+      assert_instance_of CircuitBreaker::Properties, circuit_breaker.properties
+      assert_equal 51, circuit_breaker.properties.error_threshold_percentage
+    end
+
+    def test_get_with_properties_instance
+      circuit_breaker = CircuitBreaker.get(key: "test", properties: CircuitBreaker::Properties.new({error_threshold_percentage: 51}))
+      assert_instance_of CircuitBreaker::Properties, circuit_breaker.properties
+      assert_equal 51, circuit_breaker.properties.error_threshold_percentage
+    end
+
     def test_get_with_different_properties_than_initially_provided
       key = Resilient::Key.new("longmire")
       original_properties = CircuitBreaker::Properties.new(error_threshold_percentage: 10)

--- a/test/resilient/circuit_breaker_test.rb
+++ b/test/resilient/circuit_breaker_test.rb
@@ -62,6 +62,12 @@ module Resilient
       end
     end
 
+    def test_allocate
+      assert_raises NoMethodError do
+        CircuitBreaker.allocate
+      end
+    end
+
     def test_key
       assert_equal "object", @object.key.name
     end

--- a/test/resilient/circuit_breaker_test.rb
+++ b/test/resilient/circuit_breaker_test.rb
@@ -6,21 +6,21 @@ module Resilient
   class CircuitBreakerTest < Test
     def setup
       super
-      @object = CircuitBreaker.get(key: Resilient::Key.new("object"))
+      @object = CircuitBreaker.get("object")
     end
 
     include Test::CircuitBreakerInterface
 
     def test_get
-      first_initialization = CircuitBreaker.get(key: Resilient::Key.new("longmire"))
+      first_initialization = CircuitBreaker.get(Resilient::Key.new("longmire"))
       assert_instance_of CircuitBreaker, first_initialization
 
-      second_initialization = CircuitBreaker.get(key: Resilient::Key.new("longmire"))
+      second_initialization = CircuitBreaker.get(Resilient::Key.new("longmire"))
       assert_instance_of CircuitBreaker, second_initialization
       assert first_initialization.equal?(second_initialization),
         "#{first_initialization.inspect} is not the exact same object as #{second_initialization.inspect}"
 
-      string_initialization = CircuitBreaker.get(key: "longmire")
+      string_initialization = CircuitBreaker.get("longmire")
       assert_instance_of CircuitBreaker, string_initialization
       assert first_initialization.equal?(string_initialization),
         "#{first_initialization.inspect} is not the exact same object as #{string_initialization.inspect}"
@@ -28,18 +28,18 @@ module Resilient
 
     def test_get_with_nil_key
       assert_raises ArgumentError do
-        CircuitBreaker.get(key: nil)
+        CircuitBreaker.get(nil)
       end
     end
 
     def test_get_with_properties_hash
-      circuit_breaker = CircuitBreaker.get(key: "test", properties: {error_threshold_percentage: 51})
+      circuit_breaker = CircuitBreaker.get("test", properties: {error_threshold_percentage: 51})
       assert_instance_of CircuitBreaker::Properties, circuit_breaker.properties
       assert_equal 51, circuit_breaker.properties.error_threshold_percentage
     end
 
     def test_get_with_properties_instance
-      circuit_breaker = CircuitBreaker.get(key: "test", properties: CircuitBreaker::Properties.new({error_threshold_percentage: 51}))
+      circuit_breaker = CircuitBreaker.get("test", properties: CircuitBreaker::Properties.new({error_threshold_percentage: 51}))
       assert_instance_of CircuitBreaker::Properties, circuit_breaker.properties
       assert_equal 51, circuit_breaker.properties.error_threshold_percentage
     end
@@ -47,10 +47,10 @@ module Resilient
     def test_get_with_different_properties_than_initially_provided
       key = Resilient::Key.new("longmire")
       original_properties = CircuitBreaker::Properties.new(error_threshold_percentage: 10)
-      circuit_breaker = CircuitBreaker.get(key: key, properties: original_properties)
+      circuit_breaker = CircuitBreaker.get(key, properties: original_properties)
 
       different_properties = CircuitBreaker::Properties.new(error_threshold_percentage: 15)
-      different_properties_circuit_breaker = CircuitBreaker.get(key: key, properties: different_properties)
+      different_properties_circuit_breaker = CircuitBreaker.get(key, properties: different_properties)
 
       assert_equal original_properties.error_threshold_percentage,
         different_properties_circuit_breaker.properties.error_threshold_percentage
@@ -58,7 +58,7 @@ module Resilient
 
     def test_new
       assert_raises NoMethodError do
-        CircuitBreaker.new(key: Resilient::Key.new("test"))
+        CircuitBreaker.new
       end
     end
 
@@ -76,7 +76,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new(default_test_properties_options({
         error_threshold_percentage: 51,
       }))
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -88,7 +88,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new(default_test_properties_options({
         error_threshold_percentage: 49,
       }))
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -100,7 +100,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new(default_test_properties_options({
         error_threshold_percentage: 50,
       }))
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -112,7 +112,7 @@ module Resilient
       properties = CircuitBreaker::Properties.new(default_test_properties_options({
         request_volume_threshold: 5,
       }))
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       4.times { circuit_breaker.metrics.failure }
 
       assert circuit_breaker.allow_request?,
@@ -125,7 +125,7 @@ module Resilient
         error_threshold_percentage: 49,
         sleep_window_seconds: 5,
       }))
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -163,7 +163,7 @@ module Resilient
         error_threshold_percentage: 51,
         force_open: true,
       }))
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -177,7 +177,7 @@ module Resilient
         request_volume_threshold: 0,
         force_closed: true,
       }))
-      circuit_breaker = CircuitBreaker.get(properties: properties, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", properties: properties)
       circuit_breaker.success
       circuit_breaker.failure
 
@@ -187,7 +187,7 @@ module Resilient
 
     def test_success_when_open_does_reset_metrics
       metrics = Minitest::Mock.new
-      circuit_breaker = CircuitBreaker.get(metrics: metrics, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", metrics: metrics)
       circuit_breaker.instance_variable_set("@open", true)
 
       metrics.expect :reset, nil
@@ -197,7 +197,7 @@ module Resilient
 
     def test_success_when_not_open_calls_success_on_metrics
       metrics = Minitest::Mock.new
-      circuit_breaker = CircuitBreaker.get(metrics: metrics, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", metrics: metrics)
 
       metrics.expect :success, nil
       circuit_breaker.success
@@ -206,7 +206,7 @@ module Resilient
 
     def test_failure_calls_failure_on_metrics
       metrics = Minitest::Mock.new
-      circuit_breaker = CircuitBreaker.get(metrics: metrics, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", metrics: metrics)
 
       metrics.expect :failure, nil
       circuit_breaker.failure
@@ -215,7 +215,7 @@ module Resilient
 
     def test_reset_calls_reset_on_metrics
       metrics = Minitest::Mock.new
-      circuit_breaker = CircuitBreaker.get(metrics: metrics, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test", metrics: metrics)
 
       metrics.expect :reset, nil
       circuit_breaker.reset
@@ -223,14 +223,14 @@ module Resilient
     end
 
     def test_reset_sets_open_to_false
-      circuit_breaker = CircuitBreaker.get(key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test")
       circuit_breaker.reset
 
       assert_equal false, circuit_breaker.open
     end
 
     def test_reset_sets_opened_or_last_checked_at_epoch_to_zero
-      circuit_breaker = CircuitBreaker.get(key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get("test")
       circuit_breaker.reset
 
       assert_equal 0, circuit_breaker.opened_or_last_checked_at_epoch

--- a/test/resilient/circuit_breaker_test.rb
+++ b/test/resilient/circuit_breaker_test.rb
@@ -181,7 +181,8 @@ module Resilient
 
     def test_success_when_open_does_reset_metrics
       metrics = Minitest::Mock.new
-      circuit_breaker = CircuitBreaker.get(open: true, metrics: metrics, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(metrics: metrics, key: Resilient::Key.new("test"))
+      circuit_breaker.instance_variable_set("@open", true)
 
       metrics.expect :reset, nil
       circuit_breaker.success
@@ -190,7 +191,7 @@ module Resilient
 
     def test_success_when_not_open_calls_success_on_metrics
       metrics = Minitest::Mock.new
-      circuit_breaker = CircuitBreaker.get(open: false, metrics: metrics, key: Resilient::Key.new("test"))
+      circuit_breaker = CircuitBreaker.get(metrics: metrics, key: Resilient::Key.new("test"))
 
       metrics.expect :success, nil
       circuit_breaker.success

--- a/test/resilient/circuit_breaker_test.rb
+++ b/test/resilient/circuit_breaker_test.rb
@@ -20,11 +20,6 @@ module Resilient
       assert first_initialization.equal?(second_initialization),
         "#{first_initialization.inspect} is not the exact same object as #{second_initialization.inspect}"
 
-      symbol_initialization = CircuitBreaker.get(key: Resilient::Key.new(:longmire))
-      assert_instance_of CircuitBreaker, symbol_initialization
-      assert first_initialization.equal?(symbol_initialization),
-        "#{first_initialization.inspect} is not the exact same object as #{symbol_initialization.inspect}"
-
       string_initialization = CircuitBreaker.get(key: "longmire")
       assert_instance_of CircuitBreaker, string_initialization
       assert first_initialization.equal?(string_initialization),

--- a/test/resilient/circuit_breaker_test.rb
+++ b/test/resilient/circuit_breaker_test.rb
@@ -24,6 +24,11 @@ module Resilient
       assert_instance_of CircuitBreaker, symbol_initialization
       assert first_initialization.equal?(symbol_initialization),
         "#{first_initialization.inspect} is not the exact same object as #{symbol_initialization.inspect}"
+
+      string_initialization = CircuitBreaker.get(key: "longmire")
+      assert_instance_of CircuitBreaker, string_initialization
+      assert first_initialization.equal?(string_initialization),
+        "#{first_initialization.inspect} is not the exact same object as #{string_initialization.inspect}"
     end
 
     def test_get_with_nil_key

--- a/test/resilient/key_test.rb
+++ b/test/resilient/key_test.rb
@@ -17,6 +17,10 @@ module Resilient
       assert original_key.equal?(key)
     end
 
+    def test_wrap_with_nil
+      assert_nil Key.wrap(nil)
+    end
+
     def test_wrap_with_unsupported_type
       assert_raises TypeError do
         Key.wrap(Object.new)

--- a/test/resilient/key_test.rb
+++ b/test/resilient/key_test.rb
@@ -4,6 +4,19 @@ require "resilient/test/circuit_breaker_interface"
 
 module Resilient
   class KeyTest < Test
+    def test_wrap_with_string
+      key = Key.wrap("test")
+      assert_instance_of Key, key
+      assert_equal "test", key.name
+    end
+
+    def test_wrap_with_instance
+      original_key = Key.new("test")
+      key = Key.wrap(original_key)
+      assert_instance_of Key, key
+      assert original_key.equal?(key)
+    end
+
     def test_initialize_with_string
       key = Key.new("test")
       assert_equal "test", key.name

--- a/test/resilient/key_test.rb
+++ b/test/resilient/key_test.rb
@@ -23,8 +23,9 @@ module Resilient
     end
 
     def test_initialize_with_symbol
-      key = Key.new(:test)
-      assert_equal "test", key.name
+      assert_raises TypeError do
+        Key.new(:test)
+      end
     end
 
     def test_hash

--- a/test/resilient/key_test.rb
+++ b/test/resilient/key_test.rb
@@ -17,6 +17,12 @@ module Resilient
       assert original_key.equal?(key)
     end
 
+    def test_wrap_with_unsupported_type
+      assert_raises TypeError do
+        Key.wrap(Object.new)
+      end
+    end
+
     def test_initialize_with_string
       key = Key.new("test")
       assert_equal "test", key.name


### PR DESCRIPTION
This adds Key#wrap and Properties#wrap to make it a little more convenient to get a new instance of a circuit breaker (with just string and hash instead of instance wrapping string and instance wrapping hash). 

Also removes the open kwarg as it was only used in tests and shouldn't be exposed to consumers of this class.

Also moves all kwargs to plain old args as it shortens the commen use case. The kwargs weren't really providing any value as most of the type you just use key and properties. metrics should rarely if ever be used. Perhaps metrics could even move into properties at some point too now that I think about it.

fyi @jbarnette who mentioned it, going to merge, but please provide feedback if you have any