### PR TITLE
Move Metrics from CB to CB::Properties

### DIFF
--- a/lib/resilient/circuit_breaker.rb
+++ b/lib/resilient/circuit_breaker.rb
@@ -88,7 +88,7 @@ module Resilient
           payload[:closed_the_circuit] = true
           close_circuit
         else
-          @properties.metrics.success
+          metrics.success
         end
         nil
       }
@@ -96,7 +96,7 @@ module Resilient
 
     def failure
       instrument("resilient.circuit_breaker.failure", key: @key) { |payload|
-        @properties.metrics.failure
+        metrics.failure
         nil
       }
     end
@@ -105,7 +105,7 @@ module Resilient
       instrument("resilient.circuit_breaker.reset", key: @key) { |payload|
         @open = false
         @opened_or_last_checked_at_epoch = 0
-        @properties.metrics.reset
+        metrics.reset
         nil
       }
     end
@@ -120,15 +120,15 @@ module Resilient
     def close_circuit
       @open = false
       @opened_or_last_checked_at_epoch = 0
-      @properties.metrics.reset
+      metrics.reset
     end
 
     def under_request_volume_threshold?
-      @properties.metrics.requests < @properties.request_volume_threshold
+      metrics.requests < @properties.request_volume_threshold
     end
 
     def under_error_threshold_percentage?
-      @properties.metrics.error_percentage < @properties.error_threshold_percentage
+      metrics.error_percentage < @properties.error_threshold_percentage
     end
 
     def open?

--- a/lib/resilient/circuit_breaker.rb
+++ b/lib/resilient/circuit_breaker.rb
@@ -57,14 +57,9 @@ module Resilient
       raise ArgumentError, "key argument is required" if key.nil?
 
       @key = Key.wrap(key)
+      @properties = Properties.wrap(properties)
       @open = false
       @opened_or_last_checked_at_epoch = 0
-
-      @properties = if properties
-        Properties.wrap(properties)
-      else
-        Properties.new
-      end
 
       @metrics = if metrics
         metrics

--- a/lib/resilient/circuit_breaker/properties.rb
+++ b/lib/resilient/circuit_breaker/properties.rb
@@ -47,6 +47,9 @@ module Resilient
       # size of buckets in statistical window
       attr_reader :bucket_size_in_seconds
 
+      # metrics instance used to keep track of success and failure
+      attr_reader :metrics
+
       def initialize(options = {})
         @force_open = options.fetch(:force_open, false)
         @force_closed = options.fetch(:force_closed, false)
@@ -66,6 +69,13 @@ module Resilient
             "window_size_in_seconds must be perfectly divisible by" +
             " bucket_size_in_seconds in order to evenly partition the buckets"
         end
+
+        @metrics = options.fetch(:metrics) {
+          Metrics.new({
+            window_size_in_seconds: @window_size_in_seconds,
+            bucket_size_in_seconds: @bucket_size_in_seconds,
+          })
+        }
       end
     end
   end

--- a/lib/resilient/circuit_breaker/properties.rb
+++ b/lib/resilient/circuit_breaker/properties.rb
@@ -12,6 +12,8 @@ module Resilient
           hash_or_instance
         when Hash
           new(hash_or_instance)
+        when NilClass
+          new
         else
           raise TypeError, "properties must be Hash or Resilient::Properties instance"
         end

--- a/test/resilient/circuit_breaker/properties_test.rb
+++ b/test/resilient/circuit_breaker/properties_test.rb
@@ -129,6 +129,29 @@ module Resilient
           })
         end
       end
+
+      def test_defaults_metrics_based_on_window_and_bucket_size
+        properties = Properties.new({
+          window_size_in_seconds: 60,
+          bucket_size_in_seconds: 10,
+        })
+        assert_equal 60, properties.metrics.window_size_in_seconds
+        assert_equal 10, properties.metrics.bucket_size_in_seconds
+      end
+
+      def test_allows_overriding_metrics
+        metrics = Metrics.new({
+          window_size_in_seconds: 60,
+          bucket_size_in_seconds: 10,
+        })
+        properties = Properties.new({
+          window_size_in_seconds: 50,
+          bucket_size_in_seconds: 25,
+          metrics: metrics,
+        })
+        assert_equal 60, properties.metrics.window_size_in_seconds
+        assert_equal 10, properties.metrics.bucket_size_in_seconds
+      end
     end
   end
 end

--- a/test/resilient/circuit_breaker/properties_test.rb
+++ b/test/resilient/circuit_breaker/properties_test.rb
@@ -27,6 +27,11 @@ module Resilient
         assert_equal original_properties.force_open, properties.force_open
       end
 
+      def test_wrap_with_nil
+        properties = Properties.wrap(nil)
+        assert_instance_of Properties, properties
+      end
+
       def test_wrap_with_unsupported_type
         assert_raises TypeError do
           Properties.wrap(Object.new)

--- a/test/resilient/circuit_breaker_test.rb
+++ b/test/resilient/circuit_breaker_test.rb
@@ -183,7 +183,7 @@ module Resilient
 
     def test_success_when_open_does_reset_metrics
       metrics = Minitest::Mock.new
-      circuit_breaker = CircuitBreaker.get("test", nil, metrics)
+      circuit_breaker = CircuitBreaker.get("test", metrics: metrics)
       circuit_breaker.instance_variable_set("@open", true)
 
       metrics.expect :reset, nil
@@ -193,7 +193,7 @@ module Resilient
 
     def test_success_when_not_open_calls_success_on_metrics
       metrics = Minitest::Mock.new
-      circuit_breaker = CircuitBreaker.get("test", nil, metrics)
+      circuit_breaker = CircuitBreaker.get("test", metrics: metrics)
 
       metrics.expect :success, nil
       circuit_breaker.success
@@ -202,7 +202,7 @@ module Resilient
 
     def test_failure_calls_failure_on_metrics
       metrics = Minitest::Mock.new
-      circuit_breaker = CircuitBreaker.get("test", nil, metrics)
+      circuit_breaker = CircuitBreaker.get("test", metrics: metrics)
 
       metrics.expect :failure, nil
       circuit_breaker.failure
@@ -211,7 +211,7 @@ module Resilient
 
     def test_reset_calls_reset_on_metrics
       metrics = Minitest::Mock.new
-      circuit_breaker = CircuitBreaker.get("test", nil, metrics)
+      circuit_breaker = CircuitBreaker.get("test", metrics: metrics)
 
       metrics.expect :reset, nil
       circuit_breaker.reset


### PR DESCRIPTION
Simplifies some stuff and feels not great, but ok. The metrics instance is just another property for the CB that can be configured. 

@kerrizor seem ok to you or is it weird to now be doing @properties.metrics.whatever in CB?

The nice stuff is it:

* avoids passing nil or something for properties when you want to inject metrics for CB
* one less parameter for get/new
* moves defaulting Metrics based on Properties to Properties#initialize from CB#initialize