### PR TITLE
Move reset to Registry from CB

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,13 @@ circuit_breaker = Resilient::CircuitBreaker.get("example", {
 
 ## Tests
 
-To ensure that you have a clean circuit for each test case, be sure to run the following in the setup for your tests (which resets each registered circuit breaker) either before every test case or at a minimum each test case that uses circuit breakers.
+To ensure that you have clean circuit breakers for each test case, be sure to run the following in the setup for your tests (which resets the default registry and thus clears all the registered circuits) either before every test case or at a minimum each test case that uses circuit breakers.
 
 ```ruby
-Resilient::CircuitBreaker.reset
+Resilient::CircuitBreaker::Registry.reset
 ```
+
+**Note**: If you use a non-default registry, you'll need to reset that on your own. If you don't know what I'm talking about, you are fine.
 
 ## Development
 

--- a/lib/resilient/circuit_breaker.rb
+++ b/lib/resilient/circuit_breaker.rb
@@ -5,13 +5,6 @@ require "resilient/circuit_breaker/registry"
 
 module Resilient
   class CircuitBreaker
-    # Public: Resets all registered circuit breakers (and thus their state/metrics).
-    # Useful for ensuring a clean environment between tests. If you are using a
-    # registry other than the default, you will need to handle resets on your own.
-    def self.reset
-      Registry.default.reset
-    end
-
     # Public: Returns an instance of circuit breaker based on key and registry.
     # Default registry is used if none is provided. If key does not exist, it is
     # registered. If key does exist, it returns registered instance instead of

--- a/lib/resilient/circuit_breaker/registry.rb
+++ b/lib/resilient/circuit_breaker/registry.rb
@@ -11,11 +11,19 @@ module Resilient
         @default = value
       end
 
+      # Public: Reset the default registry. This completely wipes all instances
+      # by swapping out the default registry for a new one and letting the old
+      # one get GC'd. Useful in tests to get a completely clean slate.
+      def self.reset
+        default.reset
+      end
+
       def initialize(source = nil)
         @source = source || {}
       end
 
-      # Setup default to new instance.
+      # Setup new instance as default. Needs to be after initialize so hash gets
+      # initialize correctly.
       @default = new
 
       # Internal: To be used by CircuitBreaker to either get an instance for a
@@ -38,7 +46,7 @@ module Resilient
       # breakers, which should only really be used for cleaning up in
       # test environment.
       def reset
-        @source.each_value(&:reset)
+        @source = {}
         nil
       end
     end

--- a/lib/resilient/test/circuit_breaker_registry_interface.rb
+++ b/lib/resilient/test/circuit_breaker_registry_interface.rb
@@ -20,18 +20,17 @@ module Resilient
       end
 
       def test_reset
-        bar_value = Minitest::Mock.new
-        wick_value = Minitest::Mock.new
-        bar_value.expect :reset, nil, []
-        wick_value.expect :reset, nil, []
-
-        @object.fetch("foo") { bar_value }
-        @object.fetch("baz") { wick_value }
+        original_foo = @object.fetch("foo") { Object.new }
+        original_bar = @object.fetch("bar") { Object.new }
 
         assert_nil @object.reset
 
-        bar_value.verify
-        wick_value.verify
+        foo = @object.fetch("foo") { Object.new }
+        bar = @object.fetch("bar") { Object.new }
+
+        # assert that the objects before and after reset are not the same object
+        refute original_foo.equal?(foo)
+        refute original_bar.equal?(bar)
       end
 
       def test_reset_empty_registry

--- a/test/resilient/circuit_breaker/registry_test.rb
+++ b/test/resilient/circuit_breaker/registry_test.rb
@@ -20,6 +20,12 @@ module Resilient
       ensure
         Registry.default = original_default
       end
+
+      def test_class_reset
+        Registry.default.fetch("foo") { "bar" }
+        Registry.reset
+        assert_equal "reset!", Registry.default.fetch("foo") { "reset!" }
+      end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,10 +5,7 @@ require "pathname"
 module Resilient
   class Test < Minitest::Test
     def setup
-      # Fully wipe out all circuit breakers before every test since all of these
-      # circuits are temporary. You don't want to do this in your test suite.
-      # Use CircuitBreaker.reset as directed in the readme.
-      CircuitBreaker::Registry.default = CircuitBreaker::Registry.new
+      CircuitBreaker::Registry.reset
     end
 
     def debug_metrics(metrics, indent: "")


### PR DESCRIPTION
Before:

```ruby
Resilient::CircuitBreaker.get("test", force_open: true)
Resilient::CircuitBreaker.reset

# properties still have force_open set to true and force_closed is not true, 
# this is because reset was clearing the state for the circuit breakers, but 
# doesn't clear the properties or the registered instance. Not clearing the 
# instance was actually confusing.
Resilient::CircuitBreaker.get("test", force_closed: true)
```

After:

```ruby
Resilient::CircuitBreaker.get("test", force_open: true)
# note Registry instead of just CircuitBreaker, CircuitBreaker.reset is now removed as it is confusing
Resilient::CircuitBreaker::Registry.reset

# properties force_closed is set to true and force_open is back to default
# of false because old registry is wiped away in reset and new instance is
# registered and thus properties for that instance below
Resilient::CircuitBreaker.get("test", force_closed: true)
```

Makes it more clear as to what is happening. We are not calling reset on each CB, but resetting the registry. This means that registered instances will be wiped away and CB properties can be changed in between tests for the same key name.