### PR TITLE
Metrics Interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ rvm:
   - 2.1.4
   - 2.2.3
 before_install: gem install bundler -v 1.10.6
+bundler_args: --without=development
 script: script/test

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 gemspec
 
-gem "guard", "~> 2.13.0"
-gem "guard-minitest", "~> 2.4.4"
+group :development do
+  gem "guard", "~> 2.13.0"
+  gem "guard-minitest", "~> 2.4.4"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "timecop", "~> 0.8"
+gem "minitest", "~> 5.8"
 
 group :development do
   gem "guard", "~> 2.13.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source "https://rubygems.org"
 gemspec
 
+gem "timecop", "~> 0.8"
+
 group :development do
   gem "guard", "~> 2.13.0"
   gem "guard-minitest", "~> 2.4.4"

--- a/examples/binary.rb
+++ b/examples/binary.rb
@@ -1,0 +1,114 @@
+# setting up load path
+require "pathname"
+root_path = Pathname(__FILE__).dirname.join("..").expand_path
+lib_path  = root_path.join("lib")
+$:.unshift(lib_path)
+
+# requiring stuff for this example
+require "pp"
+require "minitest/autorun"
+require "resilient/circuit_breaker"
+require "resilient/test/metrics_interface"
+
+# Metrics class that closes circuit on every success call and opens circuit for
+# sleep_window_seconds on every failure.
+class BinaryMetrics
+  def initialize(options = {})
+    reset
+  end
+
+  def success
+    reset
+    nil
+  end
+
+  def failure
+    @closed = false
+    nil
+  end
+
+  def reset
+    @closed = true
+    nil
+  end
+
+  def under_request_volume_threshold?(request_volume_threshold)
+    false
+  end
+
+  def under_error_threshold_percentage?(error_threshold_percentage)
+    @closed
+  end
+end
+
+class BinaryMetricsTest < Minitest::Test
+  def setup
+    @object = BinaryMetrics.new
+  end
+
+  include Resilient::Test::MetricsInterface
+end
+
+circuit_breaker = Resilient::CircuitBreaker.get("example", {
+  sleep_window_seconds: 1,
+  metrics: BinaryMetrics.new,
+})
+
+# success
+if circuit_breaker.allow_request?
+  begin
+    puts "do expensive thing"
+    circuit_breaker.success
+  rescue => boom
+    # won't get here in this example
+    circuit_breaker.failure
+  end
+else
+  raise "will not get here"
+end
+
+# failure
+if circuit_breaker.allow_request?
+  begin
+    raise
+  rescue => boom
+    circuit_breaker.failure
+    puts "failed slow, do fallback"
+  end
+else
+  raise "will not get here"
+end
+
+# fail fast
+if circuit_breaker.allow_request?
+  raise "will not get here"
+else
+  puts "failed fast, do fallback"
+end
+
+start = Time.now
+
+while (Time.now - start) < 3
+  if circuit_breaker.allow_request?
+    puts "doing a single attempt as we've failed fast for sleep_window_seconds"
+    break
+  else
+    puts "failed fast, do fallback"
+  end
+  sleep rand(0.1)
+end
+
+if circuit_breaker.allow_request?
+  raise "will not get here"
+else
+  puts "request denied because single request has not been marked success yet"
+end
+
+puts "marking single request as success"
+circuit_breaker.success
+
+if circuit_breaker.allow_request?
+  puts "circuit reset and back closed now, allowing requests"
+else
+  raise "will not get here"
+end

--- a/lib/resilient/circuit_breaker.rb
+++ b/lib/resilient/circuit_breaker.rb
@@ -117,11 +117,11 @@ module Resilient
     end
 
     def under_request_volume_threshold?
-      metrics.requests < @properties.request_volume_threshold
+      metrics.under_request_volume_threshold?(@properties.request_volume_threshold)
     end
 
     def under_error_threshold_percentage?
-      metrics.error_percentage < @properties.error_threshold_percentage
+      metrics.under_error_threshold_percentage?(@properties.error_threshold_percentage)
     end
 
     def open?

--- a/lib/resilient/circuit_breaker/metrics.rb
+++ b/lib/resilient/circuit_breaker/metrics.rb
@@ -30,6 +30,14 @@ module Resilient
         @buckets = []
       end
 
+      def under_request_volume_threshold?(request_volume_threshold)
+        requests < request_volume_threshold
+      end
+
+      def under_error_threshold_percentage?(error_threshold_percentage)
+        error_percentage < error_threshold_percentage
+      end
+
       def success
         @storage.increment(current_bucket, StorageSuccessKeys)
         prune_buckets
@@ -41,6 +49,13 @@ module Resilient
         prune_buckets
         nil
       end
+
+      def reset
+        @storage.prune(@buckets, StorageKeys)
+        nil
+      end
+
+      private
 
       def successes
         prune_buckets
@@ -73,13 +88,6 @@ module Resilient
 
         (failures / requests.to_f) * 100
       end
-
-      def reset
-        @storage.prune(@buckets, StorageKeys)
-        nil
-      end
-
-      private
 
       def current_bucket(timestamp = Time.now.to_i)
         bucket = @buckets.detect { |bucket| bucket.include?(timestamp) }

--- a/lib/resilient/circuit_breaker/metrics.rb
+++ b/lib/resilient/circuit_breaker/metrics.rb
@@ -71,7 +71,7 @@ module Resilient
         requests = successes + failures
         return 0 if failures == 0 || requests == 0
 
-        ((failures / requests.to_f) * 100).round
+        (failures / requests.to_f) * 100
       end
 
       def reset

--- a/lib/resilient/circuit_breaker/metrics.rb
+++ b/lib/resilient/circuit_breaker/metrics.rb
@@ -57,16 +57,6 @@ module Resilient
 
       private
 
-      def successes
-        prune_buckets
-        @storage.sum(@buckets, :successes)[:successes]
-      end
-
-      def failures
-        prune_buckets
-        @storage.sum(@buckets, :failures)[:failures]
-      end
-
       def requests
         prune_buckets
         requests = 0

--- a/lib/resilient/test/metrics_interface.rb
+++ b/lib/resilient/test/metrics_interface.rb
@@ -1,6 +1,16 @@
 module Resilient
   class Test
     module MetricsInterface
+      def test_responds_to_under_request_volume_threshold_predicate
+        assert_respond_to @object, :under_request_volume_threshold?
+        assert_equal 1, @object.method(:under_request_volume_threshold?).arity
+      end
+
+      def test_responds_to_under_error_threshold_percentage_predicate
+        assert_respond_to @object, :under_error_threshold_percentage?
+        assert_equal 1, @object.method(:under_error_threshold_percentage?).arity
+      end
+
       def test_responds_to_success
         assert_respond_to @object, :success
       end
@@ -15,22 +25,6 @@ module Resilient
 
       def test_failure_returns_nothing
         assert_nil @object.failure
-      end
-
-      def test_responds_to_successes
-        assert_respond_to @object, :successes
-      end
-
-      def test_responds_to_failures
-        assert_respond_to @object, :failures
-      end
-
-      def test_responds_to_requests
-        assert_respond_to @object, :requests
-      end
-
-      def test_responds_to_error_percentage
-        assert_respond_to @object, :error_percentage
       end
 
       def test_responds_to_reset

--- a/test/resilient/circuit_breaker_integration_test.rb
+++ b/test/resilient/circuit_breaker_integration_test.rb
@@ -133,7 +133,7 @@ module Resilient
 
       Timecop.freeze(bucket6) do
         33.times { circuit_breaker.success }
-        12.times { circuit_breaker.failure }
+        13.times { circuit_breaker.failure }
         refute circuit_breaker.allow_request?,
           debug_circuit_breaker(circuit_breaker)
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -53,8 +53,7 @@ module Resilient
 now: #{Time.now.utc}
 open: #{circuit_breaker.open}
 opened_or_last_checked_at_epoch: #{circuit_breaker.opened_or_last_checked_at_epoch}
-requests: #{circuit_breaker.metrics.successes} + #{circuit_breaker.metrics.failures} = #{circuit_breaker.metrics.requests}
-error_percentage: #{circuit_breaker.metrics.error_percentage}%
+metrics: #{circuit_breaker.metrics.inspect}
 buckets:
 #{debug_metrics(circuit_breaker.metrics, indent: "  ")}
 properties:


### PR DESCRIPTION
* add under_error_threshold_percentage? and under_request_volume_threshold?
* remove successes, failures, requests and error_percentage

The main reasons are that this simplifies the interface (net reduction of 2 methods) and it makes it easier to customize the metrics to do things like turn circuit breakers into binary on/off breakers based on success (close circuit) and failure (open circuit). 