### PR TITLE
Add ability to simulate the breaker being open during a block.

### DIFF
--- a/lib/resilient/circuit_breaker.rb
+++ b/lib/resilient/circuit_breaker.rb
@@ -53,11 +53,20 @@ module Resilient
       @properties = Properties.wrap(properties)
       @open = false
       @opened_or_last_checked_at_epoch = 0
+      @force_open = false
+    end
+
+    # Simulate forcing open the circuit breaker only for the duration of the given block.
+    def simulate_open
+      @force_open = true
+      yield
+    ensure
+      @force_open = false
     end
 
     def allow_request?
       instrument("resilient.circuit_breaker.allow_request", key: @key) { |payload|
-        payload[:result] = if payload[:force_open] = @properties.force_open
+        payload[:result] = if payload[:force_open] = @force_open || @properties.force_open
           false
         else
           # we still want to simulate normal behavior/metrics like open, allow

--- a/lib/resilient/version.rb
+++ b/lib/resilient/version.rb
@@ -1,3 +1,3 @@
 module Resilient
-  VERSION = "0.5.1"
+  VERSION = "0.6.0"
 end

--- a/test/resilient/circuit_breaker_test.rb
+++ b/test/resilient/circuit_breaker_test.rb
@@ -69,6 +69,22 @@ module Resilient
       assert_equal "object", @object.key.name
     end
 
+    def test_allow_request_when_simulating_open
+      properties = default_test_properties_options({
+        error_threshold_percentage: 51,
+      })
+      circuit_breaker = CircuitBreaker.get("test", properties)
+      circuit_breaker.success
+      circuit_breaker.failure
+
+      allowed = circuit_breaker.simulate_open do
+        circuit_breaker.allow_request?
+      end
+
+      assert !allowed, debug_circuit_breaker(circuit_breaker)
+      assert circuit_breaker.allow_request?, debug_circuit_breaker(circuit_breaker)
+    end
+
     def test_allow_request_when_under_error_threshold_percentage
       properties = default_test_properties_options({
         error_threshold_percentage: 51,


### PR DESCRIPTION
The goal is to allow testing of simulated breaker opening behavior for a single HTTP request without forcing the read-only property to be open or resetting the registry.